### PR TITLE
make dependence of task screenshotTests configurable

### DIFF
--- a/plugin/src/main/groovy/com/facebook/testing/screenshot/build/ScreenshotsPlugin.groovy
+++ b/plugin/src/main/groovy/com/facebook/testing/screenshot/build/ScreenshotsPlugin.groovy
@@ -5,6 +5,7 @@ import org.gradle.api.*
 class ScreenshotsPluginExtension {
     def adb = "adb"
     def testApkTarget = "packageDebugAndroidTest"
+    def connectedAndroidTestTarget = "connectedAndroidTest"
     def customTestRunner = false
     def recordDir = "screenshots"
     def addCompileDeps = true
@@ -66,7 +67,7 @@ class ScreenshotsPlugin implements Plugin<Project> {
     project.afterEvaluate {
       project.task("screenshotTests")
       project.screenshotTests.dependsOn project.clearScreenshots
-      project.screenshotTests.dependsOn project.connectedAndroidTest
+      project.screenshotTests.dependsOn project.screenshots.connectedAndroidTestTarget
       project.screenshotTests.dependsOn project.pullScreenshots
 
       project.pullScreenshots.dependsOn project.screenshots.testApkTarget


### PR DESCRIPTION
this commit can dramatically decrease the dependency of task screenshotTests.

For example, in my project, I use many flavors to generate different apk for different countries.
If screenshotTests depends on connectedAndroidTest, at the same time connectedAndroidTest depends on connectedDebugAndroidTest for all countries. 

The graph is like below

```
app:connectedAndroidTest - Installs and runs instrumentation tests for all flavors on connected devices. [app:connectedCountry1DebugAndroidTest, app:connectedInternationalDebugAndroidTest, app:connectedCountryIDebugAndroidTest, app:connectedCountryMDebugAndroidTest, app:connectedCountryPDebugAndroidTest, app:connectedCountrySDebugAndroidTest, app:connectedCountryTDebugAndroidTest, app:connectedCountryTaDebugAndroidTest, app:connectedCountryVDebugAndroidTest]


app:connectedCountry1DebugAndroidTest - Installs and runs the tests for Country1Debug on connected devices. [app:compileCountry1DebugAndroidTestSources, app:compileCountry1DebugSources, appkit:bundleRelease, protocol:bundleRelease]
    app:assembleCountry1Debug
    app:assembleCountry1DebugAndroidTest
    app:collectCountry1DebugMultiDexComponents
    app:createCountry1DebugMainDexClassList
    app:dexCountry1Debug
    app:dexCountry1DebugAndroidTest
    app:packageAllCountry1DebugClassesForMultiDex
    app:packageCountry1Debug
    app:packageCountry1DebugAndroidTest
    app:preDexCountry1DebugAndroidTest
    app:shrinkCountry1DebugMultiDexComponents
    app:validateDebugSigning
    app:zipalignCountry1Debug

    
app:connectedCountry...DebugAndroidTest
.....
```

It means that **every** screenshotTests call will trigger **all** connectedAndroidTest to build an apk for before generating screenshots. It's too heavy.


With the connectedAndroidTestTarget, user can set project's dependence clearly. So a screenshotTests cost 3 minutes instead of 3 * N minutes. 

```
screenshots {
    connectedAndroidTestTarget = "connectedCountry1DebugAndroidTest"
}
```
