### PR TITLE
screenshot names cannot contain path separators

### DIFF
--- a/core/src/androidTest/java/com/facebook/testing/screenshot/internal/ScreenshotImplTest.java
+++ b/core/src/androidTest/java/com/facebook/testing/screenshot/internal/ScreenshotImplTest.java
@@ -255,6 +255,13 @@ public class ScreenshotImplTest {
       .record();
   }
 
+  @Test(expected=IllegalArgumentException.class)
+  public void testNamesContainingPathSeparatorsResultInException() {
+    mScreenshot.snap(mTextView)
+      .setName("simple/test")
+      .record();
+  }
+
   @Test
   public void testMultipleOfTileSize() throws Throwable {
     measureAndLayout(512, 512);

--- a/core/src/main/java/com/facebook/testing/screenshot/internal/RecordBuilderImpl.java
+++ b/core/src/main/java/com/facebook/testing/screenshot/internal/RecordBuilderImpl.java
@@ -9,6 +9,7 @@
 
 package com.facebook.testing.screenshot.internal;
 
+import java.io.File;
 import java.nio.charset.Charset;
 import java.nio.charset.CharsetEncoder;
 import java.util.HashMap;
@@ -64,6 +65,10 @@ public class RecordBuilderImpl implements RecordBuilder {
     if (!charsetEncoder.canEncode(name)) {
       throw new IllegalArgumentException(
         "Screenshot names must have only latin characters: " + name);
+    }
+    if (name.contains(File.separator)) {
+      throw new IllegalArgumentException(
+        "Screenshot names cannot contain '" + File.separator + "': " + name);
     }
 
     mName = name;


### PR DESCRIPTION
```
java.lang.RuntimeException: java.lang.RuntimeException: java.io.FileNotFoundException: /sdcard/screenshots/com.example.app.debug.test/screenshots-default/test / NEXUS_5X (portrait).png: open failed: ENOENT (No such file or directory)
at com.facebook.testing.screenshot.internal.ScreenshotImpl.runCallableOnUiThread(ScreenshotImpl.java:311)
at com.facebook.testing.screenshot.internal.ScreenshotImpl.storeBitmap(ScreenshotImpl.java:127)
at com.facebook.testing.screenshot.internal.ScreenshotImpl.record(ScreenshotImpl.java:247)
at com.facebook.testing.screenshot.internal.RecordBuilderImpl.record(RecordBuilderImpl.java:143)
at com.example.app.ui.ToolbarTest.capture(ToolbarTest.java:29)
at com.example.app.ui.ToolbarTest.testRendering(ToolbarTest.java:47)
at java.lang.reflect.Method.invoke(Native Method)
at java.lang.reflect.Method.invoke(Method.java:372)
at android.test.InstrumentationTestCase.runMethod(InstrumentationTestCase.java:214)
at android.test.InstrumentationTestCase.runTest(InstrumentationTestCase.java:199)
at junit.framework.TestCase.runBare(TestCase.java:134)
at junit.framework.TestResult$1.protect(TestResult.java:115)
at android.support.test.internal.runner.junit3.AndroidTestResult.runProtected(AndroidTestResult.java:77)
at junit.framework.TestResult.run(TestResult.java:118)
at android.support.test.internal.runner.junit3.AndroidTestResult.run(AndroidTestResult.java:55)
at junit.framework.TestCase.run(TestCase.java:124)
at android.support.test.internal.runner.junit3.NonLeakyTestSuite$NonLeakyTest.run(NonLeakyTestSuite.java:63)
at junit.framework.TestSuite.runTest(TestSuite.java:243)
at junit.framework.TestSuite.run(TestSuite.java:238)
at android.support.test.internal.runner.junit3.DelegatingTestSuite.run(DelegatingTestSuite.java:103)
at android.support.test.internal.runner.junit3.AndroidTestSuite.run(AndroidTestSuite.java:69)
at android.support.test.internal.runner.junit3.JUnit38ClassRunner.run(JUnit38ClassRunner.java:90)
at org.junit.runners.Suite.runChild(Suite.java:128)
at org.junit.runners.Suite.runChild(Suite.java:27)
at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
at org.junit.runner.JUnitCore.run(JUnitCore.java:115)
at android.support.test.internal.runner.TestExecutor.execute(TestExecutor.java:54)
at android.support.test.runner.AndroidJUnitRunner.onStart(AndroidJUnitRunner.java:240)
at android.app.Instrumentation$InstrumentationThread.run(Instrumentation.java:1837)
Caused by: java.lang.RuntimeException: java.io.FileNotFoundException: /sdcard/screenshots/com.example.app.debug.test/screenshots-default/test / NEXUS_5X (portrait).png: open failed: ENOENT (No such file or directory)
at com.facebook.testing.screenshot.internal.ScreenshotImpl.storeBitmap(ScreenshotImpl.java:167)
at com.facebook.testing.screenshot.internal.ScreenshotImpl.access$000(ScreenshotImpl.java:42)
at com.facebook.testing.screenshot.internal.ScreenshotImpl$2.call(ScreenshotImpl.java:130)
at com.facebook.testing.screenshot.internal.ScreenshotImpl$2.call(ScreenshotImpl.java:127)
at com.facebook.testing.screenshot.internal.ScreenshotImpl$3.run(ScreenshotImpl.java:293)
at android.os.Handler.handleCallback(Handler.java:739)
at android.os.Handler.dispatchMessage(Handler.java:95)
at android.os.Looper.loop(Looper.java:135)
at android.app.ActivityThread.main(ActivityThread.java:5221)
at java.lang.reflect.Method.invoke(Native Method)
at java.lang.reflect.Method.invoke(Method.java:372)
at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:899)
at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:694)
Caused by: java.io.FileNotFoundException: /sdcard/screenshots/com.example.app.debug.test/screenshots-default/test / NEXUS_5X (portrait).png: open failed: ENOENT (No such file or directory)
at libcore.io.IoBridge.open(IoBridge.java:456)
at java.io.FileOutputStream.<init>(FileOutputStream.java:87)
at java.io.FileOutputStream.<init>(FileOutputStream.java:72)
at com.facebook.testing.screenshot.internal.AlbumImpl.writeBitmap(AlbumImpl.java:125)
at com.facebook.testing.screenshot.internal.ScreenshotImpl.drawTile(ScreenshotImpl.java:191)
at com.facebook.testing.screenshot.internal.ScreenshotImpl.storeBitmap(ScreenshotImpl.java:163)
... 12 more
Caused by: android.system.ErrnoException: open failed: ENOENT (No such file or directory)
at libcore.io.Posix.open(Native Method)
at libcore.io.BlockGuardOs.open(BlockGuardOs.java:186)
at libcore.io.IoBridge.open(IoBridge.java:442)
... 17 more
```