### PR TITLE
Fix lint errors and warnings

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -26,7 +26,7 @@ dependencies {
     compile 'com.google.dexmaker:dexmaker:1.0'
     compile 'com.google.dexmaker:dexmaker-mockito:1.0'
 
-    androidTestCompile 'com.android.support:support-v4:21.0.0'
+    androidTestCompile 'com.android.support:support-v4:23.1.0'
     androidTestCompile 'com.android.support.test:rules:0.3'
     androidTestCompile 'com.android.support.test.espresso:espresso-core:2.2'
 }
@@ -46,6 +46,7 @@ android {
 
     lintOptions {
         abortOnError false
+        disable 'InvalidPackage'
     }
 
     sourceSets {

--- a/core/src/androidTest/java/com/facebook/testing/screenshot/internal/HostFileSenderTest.java
+++ b/core/src/androidTest/java/com/facebook/testing/screenshot/internal/HostFileSenderTest.java
@@ -9,12 +9,6 @@
 
 package com.facebook.testing.screenshot.internal;
 
-import java.io.File;
-import java.io.IOException;
-import java.io.PrintWriter;
-import java.util.ArrayList;
-import java.util.List;
-
 import android.app.Instrumentation;
 import android.os.Bundle;
 import android.support.test.runner.AndroidJUnit4;
@@ -24,6 +18,13 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.List;
+
 import static org.junit.Assert.*;
 
 /**
@@ -58,9 +59,17 @@ public class HostFileSenderTest {
 
   private File newFile(String filename) throws IOException {
     File file = mFolder.newFile(filename);
-    try (PrintWriter printWriter = new PrintWriter(file)) {
+    PrintWriter printWriter = null;
+
+    try {
+      printWriter = new PrintWriter(file);
       printWriter.append("foobar");
+    } finally {
+      if (printWriter != null) {
+        printWriter.close();
+      }
     }
+
     return file;
   }
 

--- a/core/src/main/java/com/facebook/testing/screenshot/internal/ScreenshotDirectories.java
+++ b/core/src/main/java/com/facebook/testing/screenshot/internal/ScreenshotDirectories.java
@@ -9,9 +9,10 @@
 
 package com.facebook.testing.screenshot.internal;
 
-import java.io.File;
-
 import android.content.Context;
+import android.os.Environment;
+
+import java.io.File;
 
 /**
  * Provides a directory for an Album to store its screenshots in.
@@ -30,7 +31,8 @@ class ScreenshotDirectories {
   private File getSdcardDir(String type) {
 
     String parent = String.format(
-      "/sdcard/screenshots/%s/",
+      "%sscreenshots/%s/",
+      Environment.getExternalStorageDirectory().getPath(),
       mContext.getPackageName());
 
     String child = String.format("%s/screenshots-%s", parent, type);


### PR DESCRIPTION
Hello,

I'm just starting to look into getting this library working on windows. I noticed a few lint errors I thought I'd fix. 

Its nothing big, just an out of date library, a hardcoded path to the sdcard and try-with-resources isn't supported before API 17.

Any feedback would be appreciated, maybe this isn't worth a pull request. 

Thanks,
Jon