### PR TITLE
Add no_dump

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@
 /build
 repo
 examples/**/build
+.idea/
+local.properties
+*.iml

--- a/core/src/main/java/com/facebook/testing/screenshot/internal/ScreenshotImpl.java
+++ b/core/src/main/java/com/facebook/testing/screenshot/internal/ScreenshotImpl.java
@@ -59,6 +59,8 @@ public class ScreenshotImpl {
   private Canvas mCanvas = null;
   private ViewHierarchy mViewHierarchy;
   private boolean mEnableBitmapReconfigure = (Build.VERSION.SDK_INT >= 19);
+  /** Flag for dumping metadata to dump.xml when taking screenshots */
+  private boolean mShouldDumpMetadata = true;
 
   public void setTileSize(int tileSize) {
     mTileSize = tileSize;
@@ -77,9 +79,11 @@ public class ScreenshotImpl {
 
   /* package */ ScreenshotImpl(
       Album album,
-      ViewHierarchy viewHierarchy) {
+      ViewHierarchy viewHierarchy,
+      boolean shouldDumpMetadata) {
     mAlbum = album;
     mViewHierarchy = viewHierarchy;
+    mShouldDumpMetadata = shouldDumpMetadata;
   }
 
   /**
@@ -236,10 +240,10 @@ public class ScreenshotImpl {
       Context context,
       Bundle args,
       HostFileSender hostFileSender) {
-    String mode = args.getString("screenshot_mode");
+    boolean dump = args.getString("no_dump") == null;
     Album album = AlbumImpl.createStreaming(context, "default", hostFileSender);
     album.cleanup();
-    return new ScreenshotImpl(album, new ViewHierarchy());
+    return new ScreenshotImpl(album, new ViewHierarchy(), dump);
   }
 
   /**
@@ -247,6 +251,9 @@ public class ScreenshotImpl {
    */
   public void record(RecordBuilderImpl recordBuilder) {
     storeBitmap(recordBuilder);
+    if (!mShouldDumpMetadata) {
+      return;
+    }
     OutputStream viewHierarchyDump = null;
     try {
       viewHierarchyDump = mAlbum.openViewHierarchyFile(recordBuilder.getName());


### PR DESCRIPTION
The tests pass but I always see this exception at the end.

```
E/AndroidRuntime(23753): java.lang.ArrayIndexOutOfBoundsException: length=12; index=-3
E/AndroidRuntime(23753): 	at org.kxml2.io.KXmlSerializer.endTag(KXmlSerializer.java:493)
E/AndroidRuntime(23753): 	at com.facebook.testing.screenshot.internal.AlbumImpl.endXml(AlbumImpl.java:76)
E/AndroidRuntime(23753): 	at com.facebook.testing.screenshot.internal.AlbumImpl.flush(AlbumImpl.java:50)
E/AndroidRuntime(23753): 	at com.facebook.testing.screenshot.internal.ScreenshotImpl.flush(ScreenshotImpl.java:120)
E/AndroidRuntime(23753): 	at com.facebook.testing.screenshot.ScreenshotRunner.onDestroy(ScreenshotRunner.java:42)
E/AndroidRuntime(23753): 	at com.facebook.testing.screenshot.CustomScreenshotTestRunner.finish(CustomScreenshotTestRunner.java:18)
E/AndroidRuntime(23753): 	at android.support.test.runner.AndroidJUnitRunner.onStart(AndroidJUnitRunner.java:237)
E/AndroidRuntime(23753): 	at android.app.Instrumentation$InstrumentationThread.run(Instrumentation.java:1853)
W/ActivityManager(  495): Error in app com.facebook.testing.screenshot.test running instrumentation ComponentInfo{com.facebook.testing.screenshot.test/com.facebook.te
```

Even if I make flush conditional on dump, it still occurs which is strange.