### PR TITLE
Don't hardcode "/sdcard/"

### DIFF
--- a/core/src/main/java/com/facebook/testing/screenshot/internal/ScreenshotDirectories.java
+++ b/core/src/main/java/com/facebook/testing/screenshot/internal/ScreenshotDirectories.java
@@ -38,16 +38,15 @@ class ScreenshotDirectories {
   }
 
   private File getSdcardDir(String type) {
+    File externalStorage = Environment.getExternalStorageDirectory();
 
-    String parent = String.format(
-      "/sdcard/screenshots/%s/",
-      mContext.getPackageName());
+    String parent = String.format("/screenshots/%s/", mContext.getPackageName());
 
     String child = String.format("%s/screenshots-%s", parent, type);
 
-    new File(parent).mkdirs();
+    new File(externalStorage, parent).mkdirs();
 
-    File dir = new File(child);
+    File dir = new File(externalStorage, child);
     dir.mkdir();
 
     if (!dir.exists()) {


### PR DESCRIPTION
This path is not guaranteed to work on every device, and does not even work on the stock emulator at all API levels.  Instead, a call should be made to Environment.getExternalStorageDirectory() to determine the proper location.

Fixes #27