### PR TITLE
Enable run locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /build
 repo
 examples/**/build
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 repo
 examples/**/build
 .idea
+*.iml

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ You can install all the artifacts to your local maven repository using
 ## Running With a Remote Service
 
 For usage with a remote testing service (e.g. Google Cloud Test Lab) where ADB is not available directly the plugin supports a "disconnected" 
-workflow.  Collect all screenshots artifacts into a single directory and run the plugin in "local mode". 
+workflow.  Collect all screenshots artifacts into a single directory and run the plugin in "local mode" using the pullScreenshotsFromDirectory task
 
 ### Example
 The location of the screenshot artifacts can be configured in the project's build.gradle:

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ The location of the screenshot artifacts can be configured in the project's buil
 
 Then, screenshots may be verified by executing the following:
 ```bash
-  $ gradle verifyMode localScreenshots
+  $ gradle verifyMode pullScreenshotsFromDirectory
 ```
 
 To record, simply change `verifyMode` to `recordMode` and the local screenshots will become the master copy

--- a/README.md
+++ b/README.md
@@ -65,6 +65,30 @@ You can install all the artifacts to your local maven repository using
   $ gradle installAll
 ```
 
+## Running With a Remote Service
+
+For usage with a remote testing service (e.g. Google Cloud Test Lab) where ADB is not available directly the plugin supports a "disconnected" 
+workflow.  Collect all screenshots artifacts into a single directory and run the plugin in "local mode". 
+
+### Example
+The location of the screenshot artifacts can be configured in the project's build.gradle:
+```groovy
+  screenshots {
+      // Points to the directory containing all the files pulled from a device
+      referenceDir = path/to/artifacts
+
+      // Your app's application id
+      targetPackage = "your.application.package"
+  }
+```
+
+Then, screenshots may be verified by executing the following:
+```bash
+  $ gradle verifyMode localScreenshots
+```
+
+To record, simply change `verifyMode` to `recordMode` and the local screenshots will become the master copy
+
 ## Join the screenshot-tests-for-android community
 
 * Website: http://facebook.github.io/screenshot-tests-for-android

--- a/plugin/src/main/groovy/com/facebook/testing/screenshot/build/ScreenshotsPlugin.groovy
+++ b/plugin/src/main/groovy/com/facebook/testing/screenshot/build/ScreenshotsPlugin.groovy
@@ -8,8 +8,9 @@ class ScreenshotsPluginExtension {
     def customTestRunner = false
     def recordDir = "screenshots"
     def addCompileDeps = true
+
+    // Only used for the pullScreenshotsFromDirectory task
     def referenceDir = ""
-    def noPull = false
     def targetPackage = ""
 
     // Deprecated. We automatically detect adb now. Using this will
@@ -64,7 +65,7 @@ class ScreenshotsPlugin implements Plugin<Project> {
         def targetPackage = project.screenshots.targetPackage
 
         if (!referenceDir || !targetPackage) {
-          printLocalUsage(getLogger(), referenceDir, targetPackage)
+          printPullFromDirectoryUsage(getLogger(), referenceDir, targetPackage)
           return;
         }
 
@@ -119,7 +120,7 @@ class ScreenshotsPlugin implements Plugin<Project> {
     return project.tasks.getByPath(project.screenshots.testApkTarget).getOutputs().getFiles().getSingleFile().getAbsolutePath()
   }
 
-  void printLocalUsage(def logger, def referenceDir, def targetPackage) {
+  void printPullFromDirectoryUsage(def logger, def referenceDir, def targetPackage) {
     logger.error(" >>> You must specify referenceDir=[$referenceDir] and targetPackage=[$targetPackage]")
     logger.error("""
       EXAMPLE screenshot config

--- a/plugin/src/main/groovy/com/facebook/testing/screenshot/build/ScreenshotsPlugin.groovy
+++ b/plugin/src/main/groovy/com/facebook/testing/screenshot/build/ScreenshotsPlugin.groovy
@@ -125,8 +125,8 @@ class ScreenshotsPlugin implements Plugin<Project> {
       EXAMPLE screenshot config
 
       screenshots {
-        // For verification against local files, this parameter points to the directory containing all the files pulled from a device
-        referenceDir = relative/path/to/artifacts
+        // This parameter points to the directory containing all the files pulled from a device
+        referenceDir = path/to/artifacts
 
         // Your app's application id
         targetPackage = "your.application.package"

--- a/plugin/src/main/groovy/com/facebook/testing/screenshot/build/ScreenshotsPlugin.groovy
+++ b/plugin/src/main/groovy/com/facebook/testing/screenshot/build/ScreenshotsPlugin.groovy
@@ -68,7 +68,7 @@ class ScreenshotsPlugin implements Plugin<Project> {
           return;
         }
 
-        println(" >>> Using (${referenceDir}) for screenshot verification")
+        logger.quiet(" >>> Using (${referenceDir}) for screenshot verification")
 
         args = ['-m', 'android_screenshot_tests.pull_screenshots', targetPackage]
         args += ["--no-pull"]
@@ -120,7 +120,7 @@ class ScreenshotsPlugin implements Plugin<Project> {
   }
 
   void printLocalUsage(def referenceDir, def targetPackage) {
-    println(" >>> You must specify referenceDir=$referenceDir and targetPackage=$targetPackage")
+    println(" >>> You must specify referenceDir=[$referenceDir] and targetPackage=[$targetPackage]")
     println("""
       EXAMPLE screenshot config
 
@@ -138,7 +138,7 @@ class ScreenshotsPlugin implements Plugin<Project> {
     def implementationVersion = getClass().getPackage().getImplementationVersion()
 
     if (!implementationVersion) {
-      println("WARNING: you shouldn't see this in normal operation, file a bug report if this is not a framework test")
+      logger.warn("WARNING: you shouldn't see this in normal operation, file a bug report if this is not a framework test")
       implementationVersion = '0.2.4'
     }
 

--- a/plugin/src/main/groovy/com/facebook/testing/screenshot/build/ScreenshotsPlugin.groovy
+++ b/plugin/src/main/groovy/com/facebook/testing/screenshot/build/ScreenshotsPlugin.groovy
@@ -8,6 +8,9 @@ class ScreenshotsPluginExtension {
     def customTestRunner = false
     def recordDir = "screenshots"
     def addCompileDeps = true
+    def referenceDir = ""
+    def noPull = false
+    def targetPackage = ""
 
     // Deprecated. We automatically detect adb now. Using this will
     // throw an error.
@@ -48,6 +51,64 @@ class ScreenshotsPlugin implements Plugin<Project> {
         } else if (verifyMode) {
           args += ["--verify", project.screenshots.recordDir]
         }
+      }
+    }
+
+    project.task('verifyLocalScreenshots') << {
+      project.exec {
+
+        executable = 'python'
+        environment('PYTHONPATH', jarFile)
+
+        def referenceDir = project.screenshots.referenceDir
+        def targetPackage = project.screenshots.targetPackage
+
+        if (!referenceDir) {
+          println(" >>> You must specify a referenceDir")
+          return;
+        }
+
+        if (!targetPackage) {
+          println(" >>> You must specify a targetPackage")
+          return;
+        }
+
+        println(" >>> Using (${referenceDir}) for screenshot verification")
+
+        args = ['-m', 'android_screenshot_tests.pull_screenshots', targetPackage]
+        args += ["--verify", project.screenshots.recordDir]
+        args += ["--no-pull"]
+        args += ["--temp-dir", referenceDir]
+
+      }
+    }
+
+    project.task('recordLocalScreenshots') << {
+
+      project.exec {
+
+        executable = 'python'
+        environment('PYTHONPATH', jarFile)
+
+        def referenceDir = project.screenshots.referenceDir
+        def targetPackage = project.screenshots.targetPackage
+
+        if (!referenceDir) {
+          println(" >>> You must specify a referenceDir")
+          return;
+        }
+
+        if (!targetPackage) {
+          println(" >>> You must specify a targetPackage")
+          return;
+        }
+
+        println(" >>> Using (${referenceDir}) as screenshot source")
+
+        args = ['-m', 'android_screenshot_tests.pull_screenshots', targetPackage]
+        args += ["--record", project.screenshots.recordDir]
+        args += ["--no-pull"]
+        args += ["--temp-dir", referenceDir]
       }
     }
 

--- a/plugin/src/main/groovy/com/facebook/testing/screenshot/build/ScreenshotsPlugin.groovy
+++ b/plugin/src/main/groovy/com/facebook/testing/screenshot/build/ScreenshotsPlugin.groovy
@@ -54,7 +54,7 @@ class ScreenshotsPlugin implements Plugin<Project> {
       }
     }
 
-    project.task('localScreenshots') << {
+    project.task('pullScreenshotsFromDirectory') << {
       project.exec {
 
         executable = 'python'

--- a/plugin/src/main/groovy/com/facebook/testing/screenshot/build/ScreenshotsPlugin.groovy
+++ b/plugin/src/main/groovy/com/facebook/testing/screenshot/build/ScreenshotsPlugin.groovy
@@ -64,7 +64,7 @@ class ScreenshotsPlugin implements Plugin<Project> {
         def targetPackage = project.screenshots.targetPackage
 
         if (!referenceDir || !targetPackage) {
-          printLocalUsage(referenceDir, targetPackage)
+          printLocalUsage(getLogger(), referenceDir, targetPackage)
           return;
         }
 
@@ -119,9 +119,9 @@ class ScreenshotsPlugin implements Plugin<Project> {
     return project.tasks.getByPath(project.screenshots.testApkTarget).getOutputs().getFiles().getSingleFile().getAbsolutePath()
   }
 
-  void printLocalUsage(def referenceDir, def targetPackage) {
-    println(" >>> You must specify referenceDir=[$referenceDir] and targetPackage=[$targetPackage]")
-    println("""
+  void printLocalUsage(def logger, def referenceDir, def targetPackage) {
+    logger.error(" >>> You must specify referenceDir=[$referenceDir] and targetPackage=[$targetPackage]")
+    logger.error("""
       EXAMPLE screenshot config
 
       screenshots {

--- a/plugin/src/py/android_screenshot_tests/fixtures/sdcard/screenshots/com.foo/screenshots-default/metadata_no_errors.xml
+++ b/plugin/src/py/android_screenshot_tests/fixtures/sdcard/screenshots/com.foo/screenshots-default/metadata_no_errors.xml
@@ -1,0 +1,22 @@
+<screenshots>
+  <screenshot>
+    <description />
+    <name>com.foo.ScriptsFixtureTest_testGetTextViewScreenshot</name>
+    <test_class>
+    com.facebook.testing.screenshot.ScriptsFixtureTest</test_class>
+    <test_name>testGetTextViewScreenshot</test_name>
+    <tile_width>1</tile_width>
+    <tile_height>1</tile_height>
+    <absolute_file_name>/sdcard/screenshots/com.foo/screenshots-default/com.foo.ScriptsFixtureTest_testGetTextViewScreenshot.png</absolute_file_name>
+  </screenshot>
+  <screenshot>
+    <description />
+    <name>com.foo.ScriptsFixtureTest_testSecondScreenshot</name>
+    <test_class>
+    com.facebook.testing.screenshot.ScriptsFixtureTest</test_class>
+    <test_name>testSecondScreenshot</test_name>
+    <tile_width>1</tile_width>
+    <tile_height>1</tile_height>
+    <absolute_file_name>/sdcard/screenshots/com.foo/screenshots-default/com.foo.ScriptsFixtureTest_testSecondScreenshot.png</absolute_file_name>
+  </screenshot>
+</screenshots>

--- a/plugin/src/py/android_screenshot_tests/pull_screenshots.py
+++ b/plugin/src/py/android_screenshot_tests/pull_screenshots.py
@@ -246,6 +246,9 @@ def main(argv):
         # treat process as an apk instead
         process = aapt.get_package(process)
 
+    # treat the "" given back from opts as True
+    should_perform_pull = False if "--no-pull" in opts else True
+
     puller_args = []
     if "-e" in opts:
         puller_args.append("-e")
@@ -257,7 +260,7 @@ def main(argv):
         puller_args += ["-s", opts["-s"]]
 
     return pull_screenshots(process,
-                            perform_pull=opts.get('--no-pull'),
+                            perform_pull=should_perform_pull,
                             temp_dir=opts.get('--temp-dir'),
                             filter_name_regex=opts.get('--filter-name-regex'),
                             opt_generate_png=opts.get('--generate-png'),

--- a/plugin/src/py/android_screenshot_tests/pull_screenshots.py
+++ b/plugin/src/py/android_screenshot_tests/pull_screenshots.py
@@ -187,9 +187,8 @@ def pull_screenshots(process,
                      verify=None,
                      opt_generate_png=None):
 
-    # Must give a local directory when not pulling
     if not perform_pull and temp_dir is None:
-        raise RuntimeError("""temp_dir must be given if --no-pull is present""")
+        raise RuntimeError("""You must supply a directory for temp_dir if --no-pull is present""")
 
     temp_dir = temp_dir or tempfile.mkdtemp(prefix='screenshots')
 
@@ -246,8 +245,7 @@ def main(argv):
         # treat process as an apk instead
         process = aapt.get_package(process)
 
-    # treat the "" given back from opts as True
-    should_perform_pull = False if "--no-pull" in opts else True
+    should_perform_pull = ("--no-pull" not in opts)
 
     puller_args = []
     if "-e" in opts:

--- a/plugin/src/py/android_screenshot_tests/pull_screenshots.py
+++ b/plugin/src/py/android_screenshot_tests/pull_screenshots.py
@@ -180,15 +180,20 @@ def _summary(dir):
 
 def pull_screenshots(process,
                      adb_puller,
+                     perform_pull=True,
                      temp_dir=None,
                      filter_name_regex=None,
                      record=None,
                      verify=None,
                      opt_generate_png=None):
+
     temp_dir = temp_dir or tempfile.mkdtemp(prefix='screenshots')
+
     copy_assets(temp_dir)
 
-    pull_filtered(process, adb_puller=adb_puller, dir=temp_dir, filter_name_regex=filter_name_regex)
+    if perform_pull is None or perform_pull is True:
+        pull_filtered(process, adb_puller=adb_puller, dir=temp_dir, filter_name_regex=filter_name_regex)
+
     path_to_html = generate_html(temp_dir)
 
     if record or verify:
@@ -220,7 +225,7 @@ def main(argv):
         opt_list, rest_args = getopt.gnu_getopt(
             argv[1:],
             "eds:",
-            ["generate-png=", "filter-name-regex=", "apk", "record=", "verify="])
+            ["generate-png=", "filter-name-regex=", "apk", "record=", "verify=", "temp-dir=", "no-pull"])
     except getopt.GetoptError as err:
         usage()
         return 2
@@ -248,6 +253,8 @@ def main(argv):
         puller_args += ["-s", opts["-s"]]
 
     return pull_screenshots(process,
+                            perform_pull=opts.get('--no-pull'),
+                            temp_dir=opts.get('--temp-dir'),
                             filter_name_regex=opts.get('--filter-name-regex'),
                             opt_generate_png=opts.get('--generate-png'),
                             record=opts.get('--record'),

--- a/plugin/src/py/android_screenshot_tests/pull_screenshots.py
+++ b/plugin/src/py/android_screenshot_tests/pull_screenshots.py
@@ -187,11 +187,15 @@ def pull_screenshots(process,
                      verify=None,
                      opt_generate_png=None):
 
+    # Must give a local directory when not pulling
+    if not perform_pull and temp_dir is None:
+        raise RuntimeError("""temp_dir must be given if --no-pull is present""")
+
     temp_dir = temp_dir or tempfile.mkdtemp(prefix='screenshots')
 
     copy_assets(temp_dir)
 
-    if perform_pull is None or perform_pull is True:
+    if perform_pull is True:
         pull_filtered(process, adb_puller=adb_puller, dir=temp_dir, filter_name_regex=filter_name_regex)
 
     path_to_html = generate_html(temp_dir)

--- a/plugin/src/py/android_screenshot_tests/test_pull_screenshots.py
+++ b/plugin/src/py/android_screenshot_tests/test_pull_screenshots.py
@@ -107,17 +107,17 @@ class TestPullScreenshots(unittest.TestCase):
     def test_index_html_created(self):
         self.tmpdir = tempfile.mkdtemp(prefix='screenshots')
         pull_screenshots.pull_screenshots(
-                TESTING_PACKAGE,
-                adb_puller=AdbPuller(),
-                temp_dir=self.tmpdir)
+            TESTING_PACKAGE,
+            adb_puller=AdbPuller(),
+            temp_dir=self.tmpdir)
         self.assertTrue(os.path.exists(self.tmpdir + "/index.html"))
 
     def test_image_is_linked(self):
         self.tmpdir = tempfile.mkdtemp(prefix='screenshots')
         pull_screenshots.pull_screenshots(
-                TESTING_PACKAGE,
-                adb_puller=AdbPuller(),
-                temp_dir=self.tmpdir)
+            TESTING_PACKAGE,
+            adb_puller=AdbPuller(),
+            temp_dir=self.tmpdir)
         with open(self.tmpdir + "/index.html", "r") as f:
             contents = f.read()
             assertRegex(self, contents, ".*com.foo.*")

--- a/plugin/src/py/android_screenshot_tests/test_pull_screenshots.py
+++ b/plugin/src/py/android_screenshot_tests/test_pull_screenshots.py
@@ -206,5 +206,17 @@ class TestPullScreenshots(unittest.TestCase):
                                           temp_dir=source,
                                           record=dest)
 
+    def test_no_pull_argument_must_have_temp_dir(self):
+
+        try:
+            pull_screenshots.pull_screenshots(TESTING_PACKAGE,
+                                              adb_puller=None,
+                                              perform_pull=False,
+                                              temp_dir=None,
+                                              verify=tempfile.mkdtemp())
+            self.fail("expected exception")
+        except RuntimeError as e:
+            assertRegex(self, e.args[0], "temp_dir must be given if --no-pull is present")
+
 if __name__ == '__main__':
     unittest.main()

--- a/plugin/src/py/android_screenshot_tests/test_pull_screenshots.py
+++ b/plugin/src/py/android_screenshot_tests/test_pull_screenshots.py
@@ -28,7 +28,7 @@ from .common import assertRegex
 
 TESTING_PACKAGE = 'com.foo'
 CURRENT_DIR = os.path.dirname(__file__)
-FIXTURE_DIR = CURRENT_DIR + '/fixtures/sdcard/screenshots/com.foo/screenshots-default'
+FIXTURE_DIR = '%s/fixtures/sdcard/screenshots/%s/screenshots-default' % (CURRENT_DIR, TESTING_PACKAGE)
 
 
 class LocalFileHelper:

--- a/plugin/src/test/groovy/com/facebook/testing/screenshot/build/ScreenshotsPluginTest.groovy
+++ b/plugin/src/test/groovy/com/facebook/testing/screenshot/build/ScreenshotsPluginTest.groovy
@@ -33,7 +33,7 @@ class ScreenshotsPluginTest {
     def mainDir = project.projectDir.toString() + "/src/main/"
     new File(mainDir).mkdirs()
 
-    println("makig directories" + mainDir.toString())
+    println("making directories" + mainDir.toString())
 
     def manifest = new File(mainDir + "/AndroidManifest.xml")
 
@@ -140,5 +140,14 @@ class ScreenshotsPluginTest {
     } catch (IllegalArgumentException cause) {
       assertThat(cause.getMessage(), containsString("deprecated"));
     }
+  }
+
+  @Test
+  public void addsLocalScreenshotsTask() {
+    project.getPluginManager().apply 'com.android.application'
+    project.getPluginManager().apply ScreenshotsPluginForTest
+    setupProject()
+
+    assertTrue(project.tasks.localScreenshots instanceof Task)
   }
 }

--- a/plugin/src/test/groovy/com/facebook/testing/screenshot/build/ScreenshotsPluginTest.groovy
+++ b/plugin/src/test/groovy/com/facebook/testing/screenshot/build/ScreenshotsPluginTest.groovy
@@ -148,6 +148,6 @@ class ScreenshotsPluginTest {
     project.getPluginManager().apply ScreenshotsPluginForTest
     setupProject()
 
-    assertTrue(project.tasks.localScreenshots instanceof Task)
+    assertTrue(project.tasks.pullScreenshotsFromDirectory instanceof Task)
   }
 }


### PR DESCRIPTION
Adds Run Local Tasks

 This PR will close Issue #24 

    When running tests on an environment other than a local device,
    screenshots may not be accesible via ADB.  This commit enables a user to
    specify the directory of the screenshot artifacts rather than pulling
    them from a device via ADB

     - Two configurable parameters are added to the Plugin extension
        - referenceDir:  The dir containing the source screenshots artifacts
        - targetPackage: Application Id of the app under test

     - localScreenshots task is added to denote the origin of the screenshot artifacts
        - The task honors recordMode and verifyMode