### PR TITLE
Added option to set a different parent directory for sdcard

### DIFF
--- a/plugin/src/main/groovy/com/facebook/testing/screenshot/build/ScreenshotsPlugin.groovy
+++ b/plugin/src/main/groovy/com/facebook/testing/screenshot/build/ScreenshotsPlugin.groovy
@@ -54,7 +54,7 @@ class ScreenshotsPlugin implements Plugin<Project> {
     project.task("clearScreenshots") << {
       project.exec {
         executable = adb
-        args = ["shell", "rm", "-rf", "/sdcard/screenshots"]
+        args = ["shell", "rm", "-rf", "\$EXTERNAL_STORAGE/screenshots"]
         ignoreExitValue = true
       }
     }


### PR DESCRIPTION
I noticed there was an attempt at removing the hardcoded sdcard directory here. https://github.com/facebook/screenshot-tests-for-android/issues/27

Looks like this also has to be changed. I'm not sure how the plugin can get the emulator's screenshot directory dynamically so I just added an option.