### PR TITLE
Updated comment on failed directory creation

### DIFF
--- a/core/src/main/java/com/facebook/testing/screenshot/internal/ScreenshotDirectories.java
+++ b/core/src/main/java/com/facebook/testing/screenshot/internal/ScreenshotDirectories.java
@@ -58,7 +58,7 @@ class ScreenshotDirectories {
     dir.mkdir();
 
     if (!dir.exists()) {
-      throw new RuntimeException("Failed to create the directory for screenshots, do you have WRITE_EXTERNAL_STORAGE permission?");
+      throw new RuntimeException("Failed to create the directory for screenshots. Is your sdcard directory read-only?");
     }
 
     setWorldWriteable(dir);


### PR DESCRIPTION
`checkPermissions()` checks for the WRITE_EXTERNAL_STORAGE permission before `getSdcardDir()` can display this error message. The error message suggests to check if WRITE_EXTERNAL_STORAGE is set which is misleading since it should definitely be set before ever reaching this message. Added a more useful message.

https://github.com/facebook/screenshot-tests-for-android/blob/c9abe9de8bc72f23aec36c8d43cce62feadce492/core/src/main/java/com/facebook/testing/screenshot/internal/ScreenshotDirectories.java#L30