### PR TITLE
Modify WindowAttachment so View.isShown() returns true

### DIFF
--- a/core/src/androidTest/java/com/facebook/testing/screenshot/WindowAttachmentTest.java
+++ b/core/src/androidTest/java/com/facebook/testing/screenshot/WindowAttachmentTest.java
@@ -134,6 +134,7 @@ public class WindowAttachmentTest extends ActivityInstrumentationTestCase2<MyAct
       });
 
     assertNotNull(view.getWindowToken());
+    assertTrue(view.isShown());
   }
 
 

--- a/core/src/main/java/com/facebook/testing/screenshot/WindowAttachment.java
+++ b/core/src/main/java/com/facebook/testing/screenshot/WindowAttachment.java
@@ -134,9 +134,10 @@ public abstract class WindowAttachment {
       Class cAttachInfo = Class.forName("android.view.View$AttachInfo");
       Class cViewRootImpl = null;
 
-      if (Build.VERSION.SDK_INT >= 11) {
+      if (Build.VERSION.SDK_INT >= 14) {
         cViewRootImpl = Class.forName("android.view.ViewRootImpl");
       } else {
+        // honeyComb and gingerbread
         cViewRootImpl = Class.forName("android.view.ViewRoot");
       }
 

--- a/core/src/main/java/com/facebook/testing/screenshot/WindowAttachment.java
+++ b/core/src/main/java/com/facebook/testing/screenshot/WindowAttachment.java
@@ -121,6 +121,15 @@ public abstract class WindowAttachment {
    * Simulates the view as being attached.
    */
   public static void setAttachInfo(View view) {
+    int viewRootWidth = 0;
+    int viewRootHeight = 0;
+    setAttachInfo(view, viewRootWidth, viewRootHeight);
+  }
+
+  /**
+   * Simulates the view as being attached.
+   */
+  public static void setAttachInfo(View view, int viewRooWidth, int viewRootHeight) {
     try {
       Class cAttachInfo = Class.forName("android.view.View$AttachInfo");
       Class cViewRootImpl = null;
@@ -202,11 +211,15 @@ public abstract class WindowAttachment {
 
       Object attachInfo = invokeConstructor(cAttachInfo, params, values);
 
-      setField(attachInfo, "mHasWindowFocus", true);
-      setField(attachInfo, "mWindowVisibility", View.VISIBLE);
-      setField(attachInfo, "mInTouchMode", false);
+      setField(attachInfo, "mHasWindowFocus", true, cAttachInfo);
+      setField(attachInfo, "mWindowVisibility", View.VISIBLE, cAttachInfo);
+      setField(attachInfo, "mInTouchMode", false, cAttachInfo);
+      setField(view, "mParent", viewRootImpl, View.class);
+      setField(viewRootImpl, "mWidth", viewRooWidth, cViewRootImpl);
+      setField(viewRootImpl, "mHeight", viewRootHeight, cViewRootImpl);
+      setField(viewRootImpl, "mView", view, cViewRootImpl);
       if (Build.VERSION.SDK_INT >= 11) {
-        setField(attachInfo, "mHardwareAccelerated", false);
+        setField(attachInfo, "mHardwareAccelerated", false, cAttachInfo);
       }
 
       Method dispatch = View.class
@@ -273,8 +286,8 @@ public abstract class WindowAttachment {
     }
   }
 
-  private static void setField(Object o, String fieldName, Object value) throws Exception {
-    Class clazz = o.getClass();
+  private static void setField(Object o, String fieldName, Object value, Class<?> cls) throws Exception {
+    Class clazz = cls;
     Field field = clazz.getDeclaredField(fieldName);
     field.setAccessible(true);
     field.set(o, value);

--- a/core/src/main/java/com/facebook/testing/screenshot/WindowAttachment.java
+++ b/core/src/main/java/com/facebook/testing/screenshot/WindowAttachment.java
@@ -136,6 +136,8 @@ public abstract class WindowAttachment {
 
       if (Build.VERSION.SDK_INT >= 11) {
         cViewRootImpl = Class.forName("android.view.ViewRootImpl");
+      } else {
+        cViewRootImpl = Class.forName("android.view.ViewRoot");
       }
 
       Class cIWindowSession = Class.forName("android.view.IWindowSession");
@@ -194,6 +196,8 @@ public abstract class WindowAttachment {
         };
       }
       else if (Build.VERSION.SDK_INT <= 15) {
+        viewRootImpl = cViewRootImpl.getConstructor(Context.class)
+                .newInstance(context);
         params = new Class[] {
           cIWindowSession,
           cIWindow,


### PR DESCRIPTION
Some views may rely on View.isShown, for example com.facebook.drawee.view.DraweeHolder.
In this patch we set the view as a child to ViewRootImpl and set ViewRootImpl as a parent to the view.
We also set ViewRootImpl's width and height (defaults to 0, 0).