### PR TITLE
Use variant-agnostic task to build test APKs.

### DIFF
--- a/plugin/src/main/groovy/com/facebook/testing/screenshot/build/ScreenshotsPlugin.groovy
+++ b/plugin/src/main/groovy/com/facebook/testing/screenshot/build/ScreenshotsPlugin.groovy
@@ -3,7 +3,7 @@ package com.facebook.testing.screenshot.build
 import org.gradle.api.*
 
 class ScreenshotsPluginExtension {
-    def testApkTarget = "packageDebugAndroidTest"
+    def testApkTarget = "assembleAndroidTest"
     def connectedAndroidTestTarget = "connectedAndroidTest"
     def customTestRunner = false
     def recordDir = "screenshots"


### PR DESCRIPTION
This allows those with product flavors and different build types to use the library without modification.

Closes #75.