### PR TITLE
Fix for failing pull screenshot test on API 25

### DIFF
--- a/plugin/src/py/android_screenshot_tests/simple_puller.py
+++ b/plugin/src/py/android_screenshot_tests/simple_puller.py
@@ -26,7 +26,7 @@ class SimplePuller:
     def remote_file_exists(self, src):
         output = common.check_output(
             [get_adb()] + self._adb_args + ["shell",
-                                        "test -e %s && echo EXISTS" % src])
+                                        "test -e %s && echo EXISTS || echo DOES_NOT_EXIST" % src])
         return "EXISTS" in output
 
     def pull(self, src, dest):


### PR DESCRIPTION
The shell command for checking if the file exists fails for some weird reason. I've run the command on my terminal without any problems. The fix is to catch the exception and return False.