### PR TITLE
Added a possibility to change the test report location

### DIFF
--- a/plugin/src/main/groovy/com/facebook/testing/screenshot/build/ScreenshotsPlugin.groovy
+++ b/plugin/src/main/groovy/com/facebook/testing/screenshot/build/ScreenshotsPlugin.groovy
@@ -48,6 +48,11 @@ class ScreenshotsPlugin implements Plugin<Project> {
 
           args = ['-m', 'android_screenshot_tests.pull_screenshots', "--apk", output.toString()]
 
+          def referenceDir = project.screenshots.referenceDir
+          if(referenceDir) {
+            args += ["--temp-dir", referenceDir]
+          }
+
           if (recordMode) {
             args += ["--record", project.screenshots.recordDir]
           } else if (verifyMode) {

--- a/plugin/src/py/android_screenshot_tests/pull_screenshots.py
+++ b/plugin/src/py/android_screenshot_tests/pull_screenshots.py
@@ -250,6 +250,9 @@ def pull_screenshots(process,
 
     temp_dir = temp_dir or tempfile.mkdtemp(prefix='screenshots')
 
+    if not os.path.exists(temp_dir):
+        os.makedirs(temp_dir)
+
     copy_assets(temp_dir)
 
     if perform_pull is True:


### PR DESCRIPTION
As described in #80.

I've added a possibility to adjust where the test report will be saved. Example usage:

```
screenshots {
      referenceDir = "$projectDir/build/reports/screenshots"
}
```