### PR TITLE
Don't destroy the entire maven cache when cleaning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,9 +28,8 @@ set-release:
 	done
 
 cleanup:
-	rm -rf ~/.m2 ~/.gradle/caches
-	rm -rf */build/
-	rm -rf examples/one/build/
+	rm -rf ~/.m2/repository/com/facebook/testing/screenshot/ 
+	./gradlew clean
 
 integration-tests: | env-check cleanup install-local app-example-tests app-example-androidjunitrunner-tests cleanup
 	@true


### PR DESCRIPTION
Its not necessary to remove the maven and gradle caches when cleaning. `./gradlew clean` is sufficient since we re-install the necessary artifacts each time anyway.

Also deleting the entire maven and gradle cache folders is just plain mean :)