### PR TITLE
Add support for API 23+

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -34,7 +34,7 @@ dependencies {
 }
 
 android {
-    compileSdkVersion 23
+    compileSdkVersion 25
     buildToolsVersion '26.0.0'
 
     packagingOptions {
@@ -43,6 +43,7 @@ android {
 
     defaultConfig {
         minSdkVersion 9
+        targetSdkVersion 25
         testInstrumentationRunner "com.facebook.testing.screenshot.CustomScreenshotTestRunner"
     }
 

--- a/core/src/main/AndroidManifest.xml
+++ b/core/src/main/AndroidManifest.xml
@@ -3,4 +3,5 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.facebook.testing.screenshot">
    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+   <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
 </manifest>

--- a/examples/app-example/build.gradle
+++ b/examples/app-example/build.gradle
@@ -20,8 +20,13 @@ repositories {
 }
 
 android {
-    compileSdkVersion 22
+    compileSdkVersion 25
     buildToolsVersion "26.0.0"
+
+    defaultConfig {
+        minSdkVersion 9
+        targetSdkVersion 25
+    }
 
     sourceSets {
     }

--- a/examples/app-example/src/main/AndroidManifest.xml
+++ b/examples/app-example/src/main/AndroidManifest.xml
@@ -9,7 +9,6 @@
 <manifest
     xmlns:android="http://schemas.android.com/apk/res/android"
     package='com.facebook.testing.screenshot.examples'>
-   <uses-sdk android:minSdkVersion='9' android:targetSdkVersion="22" />
    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
    <application>
      <!-- not having an empty application block seems to cause the


### PR DESCRIPTION
Fixes #16 

`make integration-tests` passes on an API 25 emulator.

We should maybe track the status of https://issuetracker.google.com/issues/37077653 to introduce a "better" method of solving this issue in the future.