### PR TITLE
Improved Formatting and removed some unused stuff

### DIFF
--- a/core/src/main/java/com/facebook/testing/screenshot/RecordBuilder.java
+++ b/core/src/main/java/com/facebook/testing/screenshot/RecordBuilder.java
@@ -1,7 +1,7 @@
 /**
  * Copyright (c) 2014-present, Facebook, Inc.
  * All rights reserved.
- *
+ * <p>
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.

--- a/core/src/main/java/com/facebook/testing/screenshot/Screenshot.java
+++ b/core/src/main/java/com/facebook/testing/screenshot/Screenshot.java
@@ -1,7 +1,7 @@
 /**
  * Copyright (c) 2014-present, Facebook, Inc.
  * All rights reserved.
- *
+ * <p>
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.

--- a/core/src/main/java/com/facebook/testing/screenshot/ScreenshotRunner.java
+++ b/core/src/main/java/com/facebook/testing/screenshot/ScreenshotRunner.java
@@ -1,7 +1,7 @@
 /**
  * Copyright (c) 2014-present, Facebook, Inc.
  * All rights reserved.
- *
+ * <p>
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.

--- a/core/src/main/java/com/facebook/testing/screenshot/ViewHelpers.java
+++ b/core/src/main/java/com/facebook/testing/screenshot/ViewHelpers.java
@@ -1,7 +1,7 @@
 /**
  * Copyright (c) 2014-present, Facebook, Inc.
  * All rights reserved.
- *
+ * <p>
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
@@ -74,8 +74,8 @@ public class ViewHelpers {
   private void layoutInternal() {
     do {
       mView.measure(
-        mWidthMeasureSpec,
-        mHeightMeasureSpec);
+              mWidthMeasureSpec,
+              mHeightMeasureSpec);
       layoutView();
     } while (mView.isLayoutRequested());
   }
@@ -164,11 +164,12 @@ public class ViewHelpers {
    * views, each child has its own ViewTreeObserver.)
    */
   private void dispatchPreDraw(View view) {
-    while (view.getViewTreeObserver().dispatchOnPreDraw()) {}
+    while (view.getViewTreeObserver().dispatchOnPreDraw()) {
+    }
 
     if (view instanceof ViewGroup) {
       ViewGroup vg = (ViewGroup) view;
-      for (int i = 0 ; i < vg.getChildCount(); i++) {
+      for (int i = 0; i < vg.getChildCount(); i++) {
         dispatchPreDraw(vg.getChildAt(i));
       }
     }
@@ -179,7 +180,7 @@ public class ViewHelpers {
       WindowAttachment.Detacher detacher = WindowAttachment.dispatchAttach(mView);
       try {
         Bitmap bmp = Bitmap.createBitmap(
-          mView.getWidth(), mView.getHeight(), Bitmap.Config.ARGB_8888);
+                mView.getWidth(), mView.getHeight(), Bitmap.Config.ARGB_8888);
         Canvas canvas = new Canvas(bmp);
         mView.draw(canvas);
         return bmp;
@@ -196,6 +197,6 @@ public class ViewHelpers {
   private int dpToPx(int dp) {
     Resources resources = mView.getContext().getResources();
     return (int) TypedValue.applyDimension(
-       TypedValue.COMPLEX_UNIT_DIP, dp, resources.getDisplayMetrics());
+            TypedValue.COMPLEX_UNIT_DIP, dp, resources.getDisplayMetrics());
   }
 }

--- a/core/src/main/java/com/facebook/testing/screenshot/ViewHelpers.java
+++ b/core/src/main/java/com/facebook/testing/screenshot/ViewHelpers.java
@@ -23,14 +23,14 @@ import static android.view.View.MeasureSpec.makeMeasureSpec;
 /**
  * A collection of static utilities for measuring and pre-drawing a
  * view, usually a pre-requirement for taking a Screenshot.
- *
+ * <p>
  * This will mostly be used something like this:
- *
+ * <p>
  * <code>
- *   ViewHelpers.setupView(view)
- *     .setExactHeightPx(1000)
- *     .setExactWidthPx(100)
- *     .layout();
+ * ViewHelpers.setupView(view)
+ * .setExactHeightPx(1000)
+ * .setExactWidthPx(100)
+ * .layout();
  * </code>
  */
 public class ViewHelpers {
@@ -74,8 +74,8 @@ public class ViewHelpers {
   private void layoutInternal() {
     do {
       mView.measure(
-              mWidthMeasureSpec,
-              mHeightMeasureSpec);
+        mWidthMeasureSpec,
+        mHeightMeasureSpec);
       layoutView();
     } while (mView.isLayoutRequested());
   }
@@ -154,7 +154,7 @@ public class ViewHelpers {
   /**
    * Some views (e.g. SimpleVariableTextLayoutView) in FB4A rely on
    * the predraw. Actually I don't know why, ideally it shouldn't.
-   *
+   * <p>
    * However if you find that text is not showing in your layout, try
    * dispatching the pre draw using this method. Note this method is
    * only supported for views that are not attached to a Window, and
@@ -180,7 +180,7 @@ public class ViewHelpers {
       WindowAttachment.Detacher detacher = WindowAttachment.dispatchAttach(mView);
       try {
         Bitmap bmp = Bitmap.createBitmap(
-                mView.getWidth(), mView.getHeight(), Bitmap.Config.ARGB_8888);
+          mView.getWidth(), mView.getHeight(), Bitmap.Config.ARGB_8888);
         Canvas canvas = new Canvas(bmp);
         mView.draw(canvas);
         return bmp;
@@ -197,6 +197,6 @@ public class ViewHelpers {
   private int dpToPx(int dp) {
     Resources resources = mView.getContext().getResources();
     return (int) TypedValue.applyDimension(
-            TypedValue.COMPLEX_UNIT_DIP, dp, resources.getDisplayMetrics());
+      TypedValue.COMPLEX_UNIT_DIP, dp, resources.getDisplayMetrics());
   }
 }

--- a/core/src/main/java/com/facebook/testing/screenshot/WindowAttachment.java
+++ b/core/src/main/java/com/facebook/testing/screenshot/WindowAttachment.java
@@ -1,21 +1,13 @@
 /**
  * Copyright (c) 2014-present, Facebook, Inc.
  * All rights reserved.
- *
+ * <p>
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
 package com.facebook.testing.screenshot;
-
-import java.io.IOException;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Field;
-import java.lang.reflect.InvocationHandler;
-import java.lang.reflect.Method;
-import java.lang.reflect.Proxy;
-import java.util.WeakHashMap;
 
 import android.content.Context;
 import android.os.Binder;
@@ -29,6 +21,14 @@ import android.view.WindowManager;
 
 import com.android.dx.stock.ProxyBuilder;
 
+import java.io.IOException;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.WeakHashMap;
+
 public abstract class WindowAttachment {
 
   /**
@@ -40,13 +40,13 @@ public abstract class WindowAttachment {
   /**
    * Dispatch onAttachedToWindow to all the views in the view
    * hierarchy.
-   *
+   * <p>
    * Detach the view by calling {@code detach()} on the returned {@code Detacher}.
-   *
+   * <p>
    * Note that if the view is already attached (either via
    * WindowAttachment or to a real window), then both the attach and
    * the corresponding detach will be no-ops.
-   *
+   * <p>
    * Note that this is hacky, after these calls the views will still
    * say that isAttachedToWindow() is false and getWindowToken() ==
    * null.
@@ -72,7 +72,8 @@ public abstract class WindowAttachment {
 
   private static class NoopDetacher implements Detacher {
     @Override
-    public void detach() {}
+    public void detach() {
+    }
   }
 
   private static class RealDetacher implements Detacher {
@@ -81,6 +82,7 @@ public abstract class WindowAttachment {
     public RealDetacher(View view) {
       mView = view;
     }
+
     @Override
     public void detach() {
       dispatchDetach(mView);
@@ -111,7 +113,7 @@ public abstract class WindowAttachment {
 
     if (view instanceof ViewGroup) {
       ViewGroup vg = (ViewGroup) view;
-      for (int i = 0 ; i < vg.getChildCount(); i++) {
+      for (int i = 0; i < vg.getChildCount(); i++) {
         invokeUnchecked(vg.getChildAt(i), methodName);
       }
     }
@@ -134,7 +136,7 @@ public abstract class WindowAttachment {
       Class cCallbacks = Class.forName("android.view.View$AttachInfo$Callbacks");
 
       Context context = view.getContext();
-      WindowManager wm = (WindowManager)context.getSystemService(Context.WINDOW_SERVICE);
+      WindowManager wm = (WindowManager) context.getSystemService(Context.WINDOW_SERVICE);
       Display display = wm.getDefaultDisplay();
 
       Object viewRootImpl = null;
@@ -146,57 +148,55 @@ public abstract class WindowAttachment {
 
       if (Build.VERSION.SDK_INT >= 17) {
         viewRootImpl = cViewRootImpl.getConstructor(Context.class, Display.class)
-          .newInstance(context, display);
-        params = new Class[] {
-          cIWindowSession,
-          cIWindow,
-          Display.class,
-          cViewRootImpl,
-          Handler.class,
-          cCallbacks
+                .newInstance(context, display);
+        params = new Class[]{
+                cIWindowSession,
+                cIWindow,
+                Display.class,
+                cViewRootImpl,
+                Handler.class,
+                cCallbacks
         };
 
-        values = new Object[] {
-          stub(cIWindowSession),
-          window,
-          display,
-          viewRootImpl,
-          new Handler(),
-          stub(cCallbacks)
+        values = new Object[]{
+                stub(cIWindowSession),
+                window,
+                display,
+                viewRootImpl,
+                new Handler(),
+                stub(cCallbacks)
         };
-      }
-      else if (Build.VERSION.SDK_INT >= 16) {
+      } else if (Build.VERSION.SDK_INT >= 16) {
         viewRootImpl = cViewRootImpl.getConstructor(Context.class)
-          .newInstance(context);
-        params = new Class[] {
-          cIWindowSession,
-          cIWindow,
-          cViewRootImpl,
-          Handler.class,
-          cCallbacks
+                .newInstance(context);
+        params = new Class[]{
+                cIWindowSession,
+                cIWindow,
+                cViewRootImpl,
+                Handler.class,
+                cCallbacks
         };
 
-        values = new Object[] {
-          stub(cIWindowSession),
-          window,
-          viewRootImpl,
-          new Handler(),
-          stub(cCallbacks)
+        values = new Object[]{
+                stub(cIWindowSession),
+                window,
+                viewRootImpl,
+                new Handler(),
+                stub(cCallbacks)
         };
-      }
-      else if (Build.VERSION.SDK_INT <= 15) {
-        params = new Class[] {
-          cIWindowSession,
-          cIWindow,
-          Handler.class,
-          cCallbacks
+      } else if (Build.VERSION.SDK_INT <= 15) {
+        params = new Class[]{
+                cIWindowSession,
+                cIWindow,
+                Handler.class,
+                cCallbacks
         };
 
-        values = new Object[] {
-          stub(cIWindowSession),
-          window,
-          new Handler(),
-          stub(cCallbacks)
+        values = new Object[]{
+                stub(cIWindowSession),
+                window,
+                new Handler(),
+                stub(cCallbacks)
         };
       }
 
@@ -210,7 +210,7 @@ public abstract class WindowAttachment {
       }
 
       Method dispatch = View.class
-        .getDeclaredMethod("dispatchAttachedToWindow", cAttachInfo, int.class);
+              .getDeclaredMethod("dispatchAttachedToWindow", cAttachInfo, int.class);
       dispatch.setAccessible(true);
       dispatch.invoke(view, attachInfo, 0);
     } catch (Exception e) {
@@ -219,9 +219,9 @@ public abstract class WindowAttachment {
   }
 
   private static Object invokeConstructor(
-      Class clazz,
-      Class[] params,
-      Object[] values) throws Exception {
+          Class clazz,
+          Class[] params,
+          Object[] values) throws Exception {
     Constructor cons = clazz.getDeclaredConstructor(params);
     cons.setAccessible(true);
     return cons.newInstance(values);
@@ -232,41 +232,41 @@ public abstract class WindowAttachment {
 
     // Since IWindow is an interface, I don't need dexmaker for this
     InvocationHandler handler = new InvocationHandler() {
-        @Override
-        public Object invoke(Object proxy, Method method, Object[] args) {
-          if (method.getName().equals("asBinder")) {
-            return new Binder();
-          }
-          return null;
+      @Override
+      public Object invoke(Object proxy, Method method, Object[] args) {
+        if (method.getName().equals("asBinder")) {
+          return new Binder();
         }
-      };
+        return null;
+      }
+    };
 
     Object ret = Proxy.newProxyInstance(
-      cIWindow.getClassLoader(),
-      new Class[] { cIWindow },
-      handler);
+            cIWindow.getClassLoader(),
+            new Class[]{cIWindow},
+            handler);
 
-    return  ret;
+    return ret;
   }
 
   private static Object stub(Class klass) {
     try {
       InvocationHandler handler = new InvocationHandler() {
-          @Override
-          public Object invoke(Object project, Method method, Object[] args) {
-            return null;
-          }
-        };
+        @Override
+        public Object invoke(Object project, Method method, Object[] args) {
+          return null;
+        }
+      };
 
       if (klass.isInterface()) {
         return Proxy.newProxyInstance(
-          klass.getClassLoader(),
-          new Class[] { klass },
-          handler);
+                klass.getClassLoader(),
+                new Class[]{klass},
+                handler);
       } else {
         return ProxyBuilder.forClass(klass)
-          .handler(handler)
-          .build();
+                .handler(handler)
+                .build();
       }
     } catch (IOException e) {
       throw new RuntimeException(e);

--- a/core/src/main/java/com/facebook/testing/screenshot/WindowAttachment.java
+++ b/core/src/main/java/com/facebook/testing/screenshot/WindowAttachment.java
@@ -148,55 +148,55 @@ public abstract class WindowAttachment {
 
       if (Build.VERSION.SDK_INT >= 17) {
         viewRootImpl = cViewRootImpl.getConstructor(Context.class, Display.class)
-                .newInstance(context, display);
+          .newInstance(context, display);
         params = new Class[]{
-                cIWindowSession,
-                cIWindow,
-                Display.class,
-                cViewRootImpl,
-                Handler.class,
-                cCallbacks
+          cIWindowSession,
+          cIWindow,
+          Display.class,
+          cViewRootImpl,
+          Handler.class,
+          cCallbacks
         };
 
         values = new Object[]{
-                stub(cIWindowSession),
-                window,
-                display,
-                viewRootImpl,
-                new Handler(),
-                stub(cCallbacks)
+          stub(cIWindowSession),
+          window,
+          display,
+          viewRootImpl,
+          new Handler(),
+          stub(cCallbacks)
         };
       } else if (Build.VERSION.SDK_INT >= 16) {
         viewRootImpl = cViewRootImpl.getConstructor(Context.class)
-                .newInstance(context);
+          .newInstance(context);
         params = new Class[]{
-                cIWindowSession,
-                cIWindow,
-                cViewRootImpl,
-                Handler.class,
-                cCallbacks
+          cIWindowSession,
+          cIWindow,
+          cViewRootImpl,
+          Handler.class,
+          cCallbacks
         };
 
         values = new Object[]{
-                stub(cIWindowSession),
-                window,
-                viewRootImpl,
-                new Handler(),
-                stub(cCallbacks)
+          stub(cIWindowSession),
+          window,
+          viewRootImpl,
+          new Handler(),
+          stub(cCallbacks)
         };
       } else if (Build.VERSION.SDK_INT <= 15) {
         params = new Class[]{
-                cIWindowSession,
-                cIWindow,
-                Handler.class,
-                cCallbacks
+          cIWindowSession,
+          cIWindow,
+          Handler.class,
+          cCallbacks
         };
 
         values = new Object[]{
-                stub(cIWindowSession),
-                window,
-                new Handler(),
-                stub(cCallbacks)
+          stub(cIWindowSession),
+          window,
+          new Handler(),
+          stub(cCallbacks)
         };
       }
 
@@ -210,7 +210,7 @@ public abstract class WindowAttachment {
       }
 
       Method dispatch = View.class
-              .getDeclaredMethod("dispatchAttachedToWindow", cAttachInfo, int.class);
+        .getDeclaredMethod("dispatchAttachedToWindow", cAttachInfo, int.class);
       dispatch.setAccessible(true);
       dispatch.invoke(view, attachInfo, 0);
     } catch (Exception e) {
@@ -219,9 +219,9 @@ public abstract class WindowAttachment {
   }
 
   private static Object invokeConstructor(
-          Class clazz,
-          Class[] params,
-          Object[] values) throws Exception {
+    Class clazz,
+    Class[] params,
+    Object[] values) throws Exception {
     Constructor cons = clazz.getDeclaredConstructor(params);
     cons.setAccessible(true);
     return cons.newInstance(values);
@@ -242,9 +242,9 @@ public abstract class WindowAttachment {
     };
 
     Object ret = Proxy.newProxyInstance(
-            cIWindow.getClassLoader(),
-            new Class[]{cIWindow},
-            handler);
+      cIWindow.getClassLoader(),
+      new Class[]{cIWindow},
+      handler);
 
     return ret;
   }
@@ -260,13 +260,13 @@ public abstract class WindowAttachment {
 
       if (klass.isInterface()) {
         return Proxy.newProxyInstance(
-                klass.getClassLoader(),
-                new Class[]{klass},
-                handler);
+          klass.getClassLoader(),
+          new Class[]{klass},
+          handler);
       } else {
         return ProxyBuilder.forClass(klass)
-                .handler(handler)
-                .build();
+          .handler(handler)
+          .build();
       }
     } catch (IOException e) {
       throw new RuntimeException(e);

--- a/core/src/main/java/com/facebook/testing/screenshot/internal/Album.java
+++ b/core/src/main/java/com/facebook/testing/screenshot/internal/Album.java
@@ -1,7 +1,7 @@
 /**
  * Copyright (c) 2014-present, Facebook, Inc.
  * All rights reserved.
- *
+ * <p>
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.

--- a/core/src/main/java/com/facebook/testing/screenshot/internal/AlbumImpl.java
+++ b/core/src/main/java/com/facebook/testing/screenshot/internal/AlbumImpl.java
@@ -1,13 +1,20 @@
 /**
  * Copyright (c) 2014-present, Facebook, Inc.
  * All rights reserved.
- *
+ * <p>
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
 package com.facebook.testing.screenshot.internal;
+
+import android.content.Context;
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
+import android.util.Xml;
+
+import org.xmlpull.v1.XmlSerializer;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -17,13 +24,6 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import android.content.Context;
-import android.graphics.Bitmap;
-import android.graphics.BitmapFactory;
-import android.util.Xml;
-
-import org.xmlpull.v1.XmlSerializer;
-
 /**
  * A "local" implementation of Album.
  */
@@ -32,8 +32,7 @@ public class AlbumImpl implements Album {
   private static final int COMPRESSION_QUALITY = 90;
 
   private final File mDir;
-  private final Set<String> mAllNames = new HashSet<String>();
-  private int mTempFileNameCounter = 0;
+  private final Set<String> mAllNames = new HashSet<>();
   private XmlSerializer mXmlSerializer;
   private FileOutputStream mOutputStream;
   private HostFileSender mHostFileSender;
@@ -152,8 +151,7 @@ public class AlbumImpl implements Album {
    */
   private File getScreenshotFileInternal(String name) {
     String fileName = name + ".png";
-    File file = new File(mDir, fileName);
-    return file;
+    return new File(mDir, fileName);
   }
 
   private File getViewHierarchyFile(String name) {
@@ -180,10 +178,10 @@ public class AlbumImpl implements Album {
     if (mAllNames.contains(recordBuilder.getName())) {
       if (recordBuilder.hasExplicitName()) {
         throw new AssertionError("Can't create multiple screenshots with the same name: "
-                                 + recordBuilder.getName());
+                + recordBuilder.getName());
       } else {
         throw new AssertionError("Can't create multiple screenshots from the same test, or " +
-                                 "use .setName() to name each screenshot differently");
+                "use .setName() to name each screenshot differently");
       }
     }
 
@@ -229,19 +227,19 @@ public class AlbumImpl implements Album {
     Tiling tiling = recordBuilder.getTiling();
     for (int i = 0; i < tiling.getWidth(); i++) {
       for (int j = 0; j < tiling.getHeight(); j++) {
-        File file = getScreenshotFileInternal(tiling.getAt(i,j));
+        File file = getScreenshotFileInternal(tiling.getAt(i, j));
 
         if (!file.exists() && mHostFileSender == null) {
           throw new RuntimeException("The tile file doesn't exist");
         }
 
         addTextNode(
-          "absolute_file_name",
-          file.getAbsolutePath());
+                "absolute_file_name",
+                file.getAbsolutePath());
 
         addTextNode(
-          "relative_file_name",
-          getRelativePath(file, mDir));
+                "relative_file_name",
+                getRelativePath(file, mDir));
       }
     }
   }
@@ -279,7 +277,7 @@ public class AlbumImpl implements Album {
   /**
    * For a given screenshot, and a tile position, generates a name
    * where we store the screenshot in the album.
-   *
+   * <p>
    * For backward compatibility with existing screenshot scripts, for
    * the tile (0, 0) we use the name directly.
    */
@@ -304,9 +302,9 @@ public class AlbumImpl implements Album {
    * the host machine.
    */
   public static AlbumImpl createStreaming(
-      Context context,
-      String name,
-      HostFileSender hostFileSender) {
+          Context context,
+          String name,
+          HostFileSender hostFileSender) {
     return new AlbumImpl(new ScreenshotDirectories(context), name, hostFileSender);
   }
 }

--- a/core/src/main/java/com/facebook/testing/screenshot/internal/AlbumImpl.java
+++ b/core/src/main/java/com/facebook/testing/screenshot/internal/AlbumImpl.java
@@ -178,10 +178,10 @@ public class AlbumImpl implements Album {
     if (mAllNames.contains(recordBuilder.getName())) {
       if (recordBuilder.hasExplicitName()) {
         throw new AssertionError("Can't create multiple screenshots with the same name: "
-                + recordBuilder.getName());
+          + recordBuilder.getName());
       } else {
         throw new AssertionError("Can't create multiple screenshots from the same test, or " +
-                "use .setName() to name each screenshot differently");
+          "use .setName() to name each screenshot differently");
       }
     }
 
@@ -234,12 +234,12 @@ public class AlbumImpl implements Album {
         }
 
         addTextNode(
-                "absolute_file_name",
-                file.getAbsolutePath());
+          "absolute_file_name",
+          file.getAbsolutePath());
 
         addTextNode(
-                "relative_file_name",
-                getRelativePath(file, mDir));
+          "relative_file_name",
+          getRelativePath(file, mDir));
       }
     }
   }
@@ -302,9 +302,9 @@ public class AlbumImpl implements Album {
    * the host machine.
    */
   public static AlbumImpl createStreaming(
-          Context context,
-          String name,
-          HostFileSender hostFileSender) {
+    Context context,
+    String name,
+    HostFileSender hostFileSender) {
     return new AlbumImpl(new ScreenshotDirectories(context), name, hostFileSender);
   }
 }

--- a/core/src/main/java/com/facebook/testing/screenshot/internal/HostFileSender.java
+++ b/core/src/main/java/com/facebook/testing/screenshot/internal/HostFileSender.java
@@ -1,7 +1,7 @@
 /**
  * Copyright (c) 2014-present, Facebook, Inc.
  * All rights reserved.
- *
+ * <p>
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
@@ -9,15 +9,14 @@
 
 package com.facebook.testing.screenshot.internal;
 
-import java.io.File;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
-
 import android.app.Activity;
 import android.app.Instrumentation;
 import android.os.Bundle;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
 
 /**
  * Abstraction for sending a file to the host system while the test is
@@ -34,7 +33,6 @@ import android.os.Bundle;
  * discard all files sent to it immediately.
  */
 public class HostFileSender {
-  final int QUEUE_SIZE = 5;
   private final List<File> mQueue = new ArrayList<>();
 
   private Instrumentation mInstrumentation;
@@ -102,6 +100,7 @@ public class HostFileSender {
 
   synchronized private void waitForQueue() {
     updateQueue();
+    int QUEUE_SIZE = 5;
     while (getQueueSize() >= QUEUE_SIZE) {
       try {
         Thread.sleep(20);

--- a/core/src/main/java/com/facebook/testing/screenshot/internal/HostFileSender.java
+++ b/core/src/main/java/com/facebook/testing/screenshot/internal/HostFileSender.java
@@ -21,7 +21,7 @@ import java.util.List;
 /**
  * Abstraction for sending a file to the host system while the test is
  * running.
- *
+ * <p>
  * When running screenshot tests, the space on the emulator disk can
  * fill up quickly, therefore this tool starts streaming the
  * screenshots while the test is running. However it is the
@@ -45,7 +45,7 @@ public class HostFileSender {
 
   /**
    * Sends the given file to the host system.
-   *
+   * <p>
    * Once passed in the file is "owned" by HostFileSender and should
    * not be modified beyond this point.
    */

--- a/core/src/main/java/com/facebook/testing/screenshot/internal/RecordBuilderImpl.java
+++ b/core/src/main/java/com/facebook/testing/screenshot/internal/RecordBuilderImpl.java
@@ -1,7 +1,7 @@
 /**
  * Copyright (c) 2014-present, Facebook, Inc.
  * All rights reserved.
- *
+ * <p>
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
@@ -9,16 +9,16 @@
 
 package com.facebook.testing.screenshot.internal;
 
+import android.graphics.Bitmap;
+import android.view.View;
+
+import com.facebook.testing.screenshot.RecordBuilder;
+
 import java.io.File;
 import java.nio.charset.Charset;
 import java.nio.charset.CharsetEncoder;
 import java.util.HashMap;
 import java.util.Map;
-
-import android.graphics.Bitmap;
-import android.view.View;
-
-import com.facebook.testing.screenshot.RecordBuilder;
 
 /**
  * A builder for all the metadata associated with a screenshot.
@@ -66,11 +66,11 @@ public class RecordBuilderImpl implements RecordBuilder {
 
     if (!charsetEncoder.canEncode(name)) {
       throw new IllegalArgumentException(
-        "Screenshot names must have only latin characters: " + name);
+          "Screenshot names must have only latin characters: " + name);
     }
     if (name.contains(File.separator)) {
       throw new IllegalArgumentException(
-        "Screenshot names cannot contain '" + File.separator + "': " + name);
+          "Screenshot names cannot contain '" + File.separator + "': " + name);
     }
 
     mName = name;

--- a/core/src/main/java/com/facebook/testing/screenshot/internal/Registry.java
+++ b/core/src/main/java/com/facebook/testing/screenshot/internal/Registry.java
@@ -1,7 +1,7 @@
 /**
  * Copyright (c) 2014-present, Facebook, Inc.
  * All rights reserved.
- *
+ * <p>
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
@@ -21,6 +21,7 @@ public class Registry {
   public Bundle arguments;
 
   private static Registry sRegistry;
+
   public static Registry getRegistry() {
     if (sRegistry == null) {
       sRegistry = new Registry();

--- a/core/src/main/java/com/facebook/testing/screenshot/internal/ScreenshotDirectories.java
+++ b/core/src/main/java/com/facebook/testing/screenshot/internal/ScreenshotDirectories.java
@@ -1,7 +1,7 @@
 /**
  * Copyright (c) 2014-present, Facebook, Inc.
  * All rights reserved.
- *
+ * <p>
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
@@ -12,7 +12,6 @@ package com.facebook.testing.screenshot.internal;
 import android.content.Context;
 import android.content.pm.PackageManager;
 import android.os.Build;
-import android.os.Environment;
 
 import java.io.File;
 
@@ -36,7 +35,7 @@ class ScreenshotDirectories {
     if (res != PackageManager.PERMISSION_GRANTED) {
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
         throw new RuntimeException("This does not currently work on API 23+, see "
-            + "https://github.com/facebook/screenshot-tests-for-android/issues/16 for details.");
+                + "https://github.com/facebook/screenshot-tests-for-android/issues/16 for details.");
       } else {
         throw new RuntimeException("We need WRITE_EXTERNAL_STORAGE permission for screenshot tests");
       }
@@ -51,9 +50,9 @@ class ScreenshotDirectories {
     }
 
     String parent = String.format(
-      "%s/screenshots/%s/",
-      externalStorage,
-      mContext.getPackageName());
+            "%s/screenshots/%s/",
+            externalStorage,
+            mContext.getPackageName());
 
     String child = String.format("%s/screenshots-%s", parent, type);
 
@@ -65,13 +64,6 @@ class ScreenshotDirectories {
     if (!dir.exists()) {
       throw new RuntimeException("Failed to create the directory for screenshots. Is your sdcard directory read-only?");
     }
-
-    setWorldWriteable(dir);
-    return dir;
-  }
-
-  private File getDataDir(String type) {
-    File dir = mContext.getDir("screenshots-" + type, Context.MODE_WORLD_READABLE);
 
     setWorldWriteable(dir);
     return dir;

--- a/core/src/main/java/com/facebook/testing/screenshot/internal/ScreenshotDirectories.java
+++ b/core/src/main/java/com/facebook/testing/screenshot/internal/ScreenshotDirectories.java
@@ -35,7 +35,7 @@ class ScreenshotDirectories {
     if (res != PackageManager.PERMISSION_GRANTED) {
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
         throw new RuntimeException("This does not currently work on API 23+, see "
-                + "https://github.com/facebook/screenshot-tests-for-android/issues/16 for details.");
+          + "https://github.com/facebook/screenshot-tests-for-android/issues/16 for details.");
       } else {
         throw new RuntimeException("We need WRITE_EXTERNAL_STORAGE permission for screenshot tests");
       }
@@ -50,9 +50,9 @@ class ScreenshotDirectories {
     }
 
     String parent = String.format(
-            "%s/screenshots/%s/",
-            externalStorage,
-            mContext.getPackageName());
+      "%s/screenshots/%s/",
+      externalStorage,
+      mContext.getPackageName());
 
     String child = String.format("%s/screenshots-%s", parent, type);
 

--- a/core/src/main/java/com/facebook/testing/screenshot/internal/ScreenshotImpl.java
+++ b/core/src/main/java/com/facebook/testing/screenshot/internal/ScreenshotImpl.java
@@ -76,8 +76,8 @@ public class ScreenshotImpl {
   }
 
   /* package */ ScreenshotImpl(
-          Album album,
-          ViewHierarchy viewHierarchy) {
+    Album album,
+    ViewHierarchy viewHierarchy) {
     mAlbum = album;
     mViewHierarchy = viewHierarchy;
   }
@@ -94,8 +94,8 @@ public class ScreenshotImpl {
           return snapActivity(activity);
         }
       })
-              .setTestClass(TestNameDetector.getTestClass())
-              .setTestName(TestNameDetector.getTestName());
+        .setTestClass(TestNameDetector.getTestClass())
+        .setTestName(TestNameDetector.getTestName());
     }
     View rootView = activity.getWindow().getDecorView();
     return snap(rootView);
@@ -107,9 +107,9 @@ public class ScreenshotImpl {
    */
   public RecordBuilderImpl snap(final View measuredView) {
     RecordBuilderImpl recordBuilder = new RecordBuilderImpl(this)
-            .setView(measuredView)
-            .setTestClass(TestNameDetector.getTestClass())
-            .setTestName(TestNameDetector.getTestName());
+      .setView(measuredView)
+      .setTestClass(TestNameDetector.getTestClass())
+      .setTestName(TestNameDetector.getTestName());
 
     return recordBuilder;
   }
@@ -137,7 +137,7 @@ public class ScreenshotImpl {
 
     View measuredView = recordBuilder.getView();
     if (measuredView.getMeasuredHeight() == 0 ||
-            measuredView.getMeasuredWidth() == 0) {
+      measuredView.getMeasuredWidth() == 0) {
       throw new RuntimeException("Can't take a screenshot, since this view is not measured");
     }
 
@@ -164,7 +164,7 @@ public class ScreenshotImpl {
 
   @TargetApi(Build.VERSION_CODES.KITKAT)
   private void drawTile(View measuredView, int i, int j, RecordBuilderImpl recordBuilder)
-          throws IOException {
+    throws IOException {
     int width = measuredView.getWidth();
     int height = measuredView.getHeight();
     int left = i * mTileSize;
@@ -193,9 +193,9 @@ public class ScreenshotImpl {
       return;
     }
     mBitmap = Bitmap.createBitmap(
-            mTileSize,
-            mTileSize,
-            Bitmap.Config.ARGB_8888);
+      mTileSize,
+      mTileSize,
+      Bitmap.Config.ARGB_8888);
     mCanvas = new Canvas(mBitmap);
   }
 
@@ -224,8 +224,8 @@ public class ScreenshotImpl {
    * are passed to the instrumentation
    */
   private static ScreenshotImpl create(
-          Context context,
-          HostFileSender hostFileSender) {
+    Context context,
+    HostFileSender hostFileSender) {
     Album album = AlbumImpl.createStreaming(context, "default", hostFileSender);
     album.cleanup();
     return new ScreenshotImpl(album, new ViewHierarchy());
@@ -261,9 +261,9 @@ public class ScreenshotImpl {
 
     View view = recordBuilder.getView();
     Bitmap bmp = Bitmap.createBitmap(
-            view.getWidth(),
-            view.getHeight(),
-            Bitmap.Config.ARGB_8888);
+      view.getWidth(),
+      view.getHeight(),
+      Bitmap.Config.ARGB_8888);
 
     WindowAttachment.Detacher detacher = WindowAttachment.dispatchAttach(recordBuilder.getView());
     try {
@@ -333,12 +333,12 @@ public class ScreenshotImpl {
       Bundle arguments = Registry.getRegistry().arguments;
 
       HostFileSender hostFileSender = new HostFileSender(
-              instrumentation,
-              arguments);
+        instrumentation,
+        arguments);
 
       sInstance = create(
-              instrumentation.getContext(),
-              hostFileSender);
+        instrumentation.getContext(),
+        hostFileSender);
 
       return sInstance;
     }

--- a/core/src/main/java/com/facebook/testing/screenshot/internal/ScreenshotImpl.java
+++ b/core/src/main/java/com/facebook/testing/screenshot/internal/ScreenshotImpl.java
@@ -1,7 +1,7 @@
 /**
  * Copyright (c) 2014-present, Facebook, Inc.
  * All rights reserved.
- *
+ * <p>
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
@@ -32,11 +32,11 @@ import java.util.concurrent.Callable;
 
 /**
  * Implementation for Screenshot class.
- *
+ * <p>
  * The Screenshot class has static methods, because that's how the API
  * should look like, this class has all its implementation for
  * testability.
- *
+ * <p>
  * This is public only for implementation convenient for using
  * UiThreadHelper.
  */
@@ -76,8 +76,8 @@ public class ScreenshotImpl {
   }
 
   /* package */ ScreenshotImpl(
-      Album album,
-      ViewHierarchy viewHierarchy) {
+          Album album,
+          ViewHierarchy viewHierarchy) {
     mAlbum = album;
     mViewHierarchy = viewHierarchy;
   }
@@ -89,13 +89,13 @@ public class ScreenshotImpl {
   public RecordBuilderImpl snapActivity(final Activity activity) {
     if (!isUiThread()) {
       return runCallableOnUiThread(new Callable<RecordBuilderImpl>() {
-          @Override
-          public RecordBuilderImpl call() {
-            return snapActivity(activity);
-          }
-        })
-        .setTestClass(TestNameDetector.getTestClass())
-        .setTestName(TestNameDetector.getTestName());
+        @Override
+        public RecordBuilderImpl call() {
+          return snapActivity(activity);
+        }
+      })
+              .setTestClass(TestNameDetector.getTestClass())
+              .setTestName(TestNameDetector.getTestName());
     }
     View rootView = activity.getWindow().getDecorView();
     return snap(rootView);
@@ -107,9 +107,9 @@ public class ScreenshotImpl {
    */
   public RecordBuilderImpl snap(final View measuredView) {
     RecordBuilderImpl recordBuilder = new RecordBuilderImpl(this)
-      .setView(measuredView)
-      .setTestClass(TestNameDetector.getTestClass())
-      .setTestName(TestNameDetector.getTestName());
+            .setView(measuredView)
+            .setTestClass(TestNameDetector.getTestClass())
+            .setTestName(TestNameDetector.getTestName());
 
     return recordBuilder;
   }
@@ -126,28 +126,19 @@ public class ScreenshotImpl {
 
     if (!isUiThread()) {
       runCallableOnUiThread(new Callable<Void>() {
-          @Override
-          public Void call() {
-            storeBitmap(recordBuilder);
-            return null;
-          }
-        });
+        @Override
+        public Void call() {
+          storeBitmap(recordBuilder);
+          return null;
+        }
+      });
       return;
     }
 
     View measuredView = recordBuilder.getView();
     if (measuredView.getMeasuredHeight() == 0 ||
-        measuredView.getMeasuredWidth() == 0) {
+            measuredView.getMeasuredWidth() == 0) {
       throw new RuntimeException("Can't take a screenshot, since this view is not measured");
-    }
-
-    int tileSize = Math.max(
-      measuredView.getWidth(),
-      measuredView.getHeight());
-
-    if (measuredView.getMeasuredHeight() * measuredView.getMeasuredWidth()
-        > TILING_THRESHOLD * mTileSize * mTileSize) {
-      tileSize = mTileSize;
     }
 
     WindowAttachment.Detacher detacher = WindowAttachment.dispatchAttach(measuredView);
@@ -173,7 +164,7 @@ public class ScreenshotImpl {
 
   @TargetApi(Build.VERSION_CODES.KITKAT)
   private void drawTile(View measuredView, int i, int j, RecordBuilderImpl recordBuilder)
-      throws IOException {
+          throws IOException {
     int width = measuredView.getWidth();
     int height = measuredView.getHeight();
     int left = i * mTileSize;
@@ -202,9 +193,9 @@ public class ScreenshotImpl {
       return;
     }
     mBitmap = Bitmap.createBitmap(
-      mTileSize,
-      mTileSize,
-      Bitmap.Config.ARGB_8888);
+            mTileSize,
+            mTileSize,
+            Bitmap.Config.ARGB_8888);
     mCanvas = new Canvas(mBitmap);
   }
 
@@ -217,7 +208,7 @@ public class ScreenshotImpl {
    * dimensions <code>(right-left)*(bottom-top)</code>, with the
    * rendering of the view starting from position (<code>left</code>,
    * <code>top</code>).
-   *
+   * <p>
    * For well behaved views, calling this repeatedly shouldn't change
    * the rendering, so it should it okay to render each tile one by
    * one and combine it later.
@@ -233,10 +224,8 @@ public class ScreenshotImpl {
    * are passed to the instrumentation
    */
   private static ScreenshotImpl create(
-      Context context,
-      Bundle args,
-      HostFileSender hostFileSender) {
-    String mode = args.getString("screenshot_mode");
+          Context context,
+          HostFileSender hostFileSender) {
     Album album = AlbumImpl.createStreaming(context, "default", hostFileSender);
     album.cleanup();
     return new ScreenshotImpl(album, new ViewHierarchy());
@@ -272,9 +261,9 @@ public class ScreenshotImpl {
 
     View view = recordBuilder.getView();
     Bitmap bmp = Bitmap.createBitmap(
-      view.getWidth(),
-      view.getHeight(),
-      Bitmap.Config.ARGB_8888);
+            view.getWidth(),
+            view.getHeight(),
+            Bitmap.Config.ARGB_8888);
 
     WindowAttachment.Detacher detacher = WindowAttachment.dispatchAttach(recordBuilder.getView());
     try {
@@ -297,20 +286,20 @@ public class ScreenshotImpl {
     final Object lock = new Object();
     Handler handler = new Handler(Looper.getMainLooper());
 
-    synchronized(lock) {
+    synchronized (lock) {
       handler.post(new Runnable() {
-          @Override
-          public void run() {
-            try {
-              ret[0] = callable.call();
-            } catch (Exception ee) {
-              e[0] = ee;
-            }
-            synchronized(lock) {
-              lock.notifyAll();
-            }
+        @Override
+        public void run() {
+          try {
+            ret[0] = callable.call();
+          } catch (Exception ee) {
+            e[0] = ee;
           }
-        });
+          synchronized (lock) {
+            lock.notifyAll();
+          }
+        }
+      });
 
       try {
         lock.wait();
@@ -335,7 +324,7 @@ public class ScreenshotImpl {
       return sInstance;
     }
 
-    synchronized(ScreenshotImpl.class) {
+    synchronized (ScreenshotImpl.class) {
       if (sInstance != null) {
         return sInstance;
       }
@@ -344,13 +333,12 @@ public class ScreenshotImpl {
       Bundle arguments = Registry.getRegistry().arguments;
 
       HostFileSender hostFileSender = new HostFileSender(
-        instrumentation,
-        arguments);
+              instrumentation,
+              arguments);
 
       sInstance = create(
-        instrumentation.getContext(),
-        arguments,
-        hostFileSender);
+              instrumentation.getContext(),
+              hostFileSender);
 
       return sInstance;
     }
@@ -358,7 +346,7 @@ public class ScreenshotImpl {
 
   /**
    * Check if getInstance() has ever been called.
-   *
+   * <p>
    * This is for a minor optimization to avoid creating a
    * ScreenshotImpl at onDestroy() if it was never called during the
    * run.

--- a/core/src/main/java/com/facebook/testing/screenshot/internal/TestNameDetector.java
+++ b/core/src/main/java/com/facebook/testing/screenshot/internal/TestNameDetector.java
@@ -1,7 +1,7 @@
 /**
  * Copyright (c) 2014-present, Facebook, Inc.
  * All rights reserved.
- *
+ * <p>
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
@@ -9,12 +9,14 @@
 
 package com.facebook.testing.screenshot.internal;
 
-import java.lang.reflect.Method;
-
 import android.util.Log;
+
 import junit.framework.TestCase;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import java.lang.reflect.Method;
 
 /**
  * Detect the test name and class that is being run currently.

--- a/core/src/main/java/com/facebook/testing/screenshot/internal/Tiling.java
+++ b/core/src/main/java/com/facebook/testing/screenshot/internal/Tiling.java
@@ -1,7 +1,7 @@
 /**
  * Copyright (c) 2014-present, Facebook, Inc.
  * All rights reserved.
- *
+ * <p>
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.

--- a/core/src/main/java/com/facebook/testing/screenshot/internal/ViewHierarchy.java
+++ b/core/src/main/java/com/facebook/testing/screenshot/internal/ViewHierarchy.java
@@ -66,8 +66,8 @@ public class ViewHierarchy {
 
     try {
       doc = DocumentBuilderFactory.newInstance()
-              .newDocumentBuilder()
-              .newDocument();
+        .newDocumentBuilder()
+        .newDocument();
     } catch (ParserConfigurationException e) {
       throw new RuntimeException(e);
     }
@@ -83,10 +83,10 @@ public class ViewHierarchy {
     addTextNode(el, "name", view.getClass().getName());
 
     Rect rect = new Rect(
-            topLeft.x + view.getLeft(),
-            topLeft.y + view.getTop(),
-            topLeft.x + view.getRight(),
-            topLeft.y + view.getBottom());
+      topLeft.x + view.getLeft(),
+      topLeft.y + view.getTop(),
+      topLeft.x + view.getRight(),
+      topLeft.y + view.getBottom());
 
     addTextNode(el, "left", String.valueOf(rect.left));
     addTextNode(el, "top", String.valueOf(rect.top));

--- a/core/src/main/java/com/facebook/testing/screenshot/internal/ViewHierarchy.java
+++ b/core/src/main/java/com/facebook/testing/screenshot/internal/ViewHierarchy.java
@@ -1,7 +1,7 @@
 /**
  * Copyright (c) 2014-present, Facebook, Inc.
  * All rights reserved.
- *
+ * <p>
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
@@ -9,20 +9,7 @@
 
 package com.facebook.testing.screenshot.internal;
 
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
-import javax.xml.transform.OutputKeys;
-import javax.xml.transform.Transformer;
-import javax.xml.transform.TransformerException;
-import javax.xml.transform.TransformerFactory;
-import javax.xml.transform.dom.DOMSource;
-import javax.xml.transform.stream.StreamResult;
-
-import java.io.IOException;
-import java.io.OutputStream;
-import java.util.HashMap;
-import java.util.Map;
-
+import android.annotation.TargetApi;
 import android.graphics.Point;
 import android.graphics.Rect;
 import android.os.Build;
@@ -35,13 +22,27 @@ import com.facebook.testing.screenshot.plugin.ViewDumpPlugin;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+
 /**
  * Dumps information about the view hierarchy.
  */
 public class ViewHierarchy {
   /**
    * Creates an XML dump for the view into given OutputStream
-   *
+   * <p>
    * This is meant for debugging purposes only, and we don't
    * guarantee that it's format will remain the same.
    */
@@ -65,8 +66,8 @@ public class ViewHierarchy {
 
     try {
       doc = DocumentBuilderFactory.newInstance()
-        .newDocumentBuilder()
-        .newDocument();
+              .newDocumentBuilder()
+              .newDocument();
     } catch (ParserConfigurationException e) {
       throw new RuntimeException(e);
     }
@@ -75,16 +76,17 @@ public class ViewHierarchy {
     return doc;
   }
 
+  @TargetApi(Build.VERSION_CODES.HONEYCOMB)
   private Element deflateRelative(View view, Point topLeft, Document doc) {
     Element el = doc.createElement("view");
 
     addTextNode(el, "name", view.getClass().getName());
 
     Rect rect = new Rect(
-      topLeft.x + view.getLeft(),
-      topLeft.y + view.getTop(),
-      topLeft.x + view.getRight(),
-      topLeft.y + view.getBottom());
+            topLeft.x + view.getLeft(),
+            topLeft.y + view.getTop(),
+            topLeft.x + view.getRight(),
+            topLeft.y + view.getBottom());
 
     addTextNode(el, "left", String.valueOf(rect.left));
     addTextNode(el, "top", String.valueOf(rect.top));

--- a/core/src/main/java/com/facebook/testing/screenshot/plugin/PluginRegistry.java
+++ b/core/src/main/java/com/facebook/testing/screenshot/plugin/PluginRegistry.java
@@ -1,7 +1,7 @@
 /**
  * Copyright (c) 2014-present, Facebook, Inc.
  * All rights reserved.
- *
+ * <p>
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.

--- a/core/src/main/java/com/facebook/testing/screenshot/plugin/TextViewDumper.java
+++ b/core/src/main/java/com/facebook/testing/screenshot/plugin/TextViewDumper.java
@@ -1,7 +1,7 @@
 /**
  * Copyright (c) 2014-present, Facebook, Inc.
  * All rights reserved.
- *
+ * <p>
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
@@ -9,10 +9,10 @@
 
 package com.facebook.testing.screenshot.plugin;
 
-import java.util.Map;
-
 import android.view.View;
 import android.widget.TextView;
+
+import java.util.Map;
 
 /**
  * Dumps useful details from a TextView

--- a/core/src/main/java/com/facebook/testing/screenshot/plugin/ViewDumpPlugin.java
+++ b/core/src/main/java/com/facebook/testing/screenshot/plugin/ViewDumpPlugin.java
@@ -1,7 +1,7 @@
 /**
  * Copyright (c) 2014-present, Facebook, Inc.
  * All rights reserved.
- *
+ * <p>
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
@@ -9,16 +9,16 @@
 
 package com.facebook.testing.screenshot.plugin;
 
-import java.util.Map;
-
 import android.view.View;
+
+import java.util.Map;
 
 /**
  * A plugin to get more metadata about a View.
- *
+ * <p>
  * When screenshots are generated we use all registered plugins to
  * generate metadata for each of the views in the hierarchy.
  */
 public interface ViewDumpPlugin {
-  public void dump(View view, Map<String, String> output);
+  void dump(View view, Map<String, String> output);
 }


### PR DESCRIPTION
- Added `<p>` separators to Javadoc strings.
- Used Android Studio Autoformat to align and open empty functions.`{}` --> `{\n}`
- Used Android Studio Autoformat to format imports.
- Removed redundant local variable `file` in `getScreenshotFileInternal()`
- Made `QUEUE_SIZE` a local variable. (It wasn't being used anywhere else)
- Removed `getDataDir(String type` function as it wasn't being used anywhere.
- Removed a chunk of code in `ScreenshotImpl.java` because it didn't seem to serve any purpose. `tileSize` was being given a value but was never used anywhere.
- Removed `Bundle args` from `ScreenshotImpl create()` because it's only usage was not being used. `mode` was not being used anywhere.
- Added a `@TargetApi` annotation to `deflateRelative()` because an unchecked function in it `view.isDirty()` is not supported for the current min api `9`.
- Removed redundant `public` function scope for a `public` interface.