### PR TITLE
Use ls instead of test

### DIFF
--- a/plugin/src/py/android_screenshot_tests/simple_puller.py
+++ b/plugin/src/py/android_screenshot_tests/simple_puller.py
@@ -26,7 +26,7 @@ class SimplePuller:
     def remote_file_exists(self, src):
         output = common.check_output(
             [get_adb()] + self._adb_args + ["shell",
-                                        "test -e %s && echo EXISTS || echo DOES_NOT_EXIST" % src])
+                                        "ls %s && echo EXISTS || echo DOES_NOT_EXIST" % src])
         return "EXISTS" in output
 
     def pull(self, src, dest):


### PR DESCRIPTION
Older versions of Android (15, for example) do not ship with test, and so pulling
screenshots always fails. This changes the method for testing
the existence of metadata.xml to use ls instead, which is
available on all Android versions.