### PR TITLE
Add ability for user to define custom directory

### DIFF
--- a/core/src/main/java/com/facebook/testing/screenshot/ScreenshotRunner.java
+++ b/core/src/main/java/com/facebook/testing/screenshot/ScreenshotRunner.java
@@ -18,15 +18,21 @@ import com.facebook.testing.screenshot.internal.ScreenshotImpl;
 /**
  * The ScreenshotRunner needs to be called from the top level
  * Instrumentation runner before and after all the tests run.
- *
+ * <p>
  * You don't need to call this directly if you're using {@code
  * ScreenshotTestRunner} as your instrumentation.
  */
 public abstract class ScreenshotRunner {
+
+  /**
+   * These strings can be used as Keys to Bundle Arguments.
+   */
+  public static final String SDCARD_DIRECTORY = "sdcard_directory";
+
   /**
    * Call this exactly once in your process before any screenshots are
    * generated.
-   *
+   * <p>
    * Typically this will be in {@code InstrumentationTestRunner#onCreate()}
    */
   public static void onCreate(Instrumentation instrumentation, Bundle arguments) {
@@ -37,7 +43,7 @@ public abstract class ScreenshotRunner {
 
   /**
    * Call this exactly once after all your tests have run.
-   *
+   * <p>
    * Typically this can be in {@code InstrumentationTestRunner#finish()}
    */
   public static void onDestroy() {

--- a/core/src/main/java/com/facebook/testing/screenshot/internal/ScreenshotDirectories.java
+++ b/core/src/main/java/com/facebook/testing/screenshot/internal/ScreenshotDirectories.java
@@ -13,17 +13,24 @@ import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.pm.PackageManager;
 import android.os.Build;
+import android.os.Bundle;
 
 import java.io.File;
+
+import static com.facebook.testing.screenshot.ScreenshotRunner.SDCARD_DIRECTORY;
 
 /**
  * Provides a directory for an Album to store its screenshots in.
  */
 class ScreenshotDirectories {
   private Context mContext;
+  private Bundle mArguments;
+
+  private static final String DEFAULT_SDCARD_DIRECTORY = "screenshots";
 
   public ScreenshotDirectories(Context context) {
     mContext = context;
+    mArguments = Registry.getRegistry().arguments;
   }
 
   public File get(String type) {
@@ -50,9 +57,12 @@ class ScreenshotDirectories {
       throw new RuntimeException("No $EXTERNAL_STORAGE has been set on the device, please report this bug!");
     }
 
+    String sdcardDirectory = mArguments.containsKey(SDCARD_DIRECTORY) ? mArguments.getString(SDCARD_DIRECTORY) : DEFAULT_SDCARD_DIRECTORY;
+
     String parent = String.format(
-        "%s/screenshots/%s/",
+        "%s/%s/%s/",
         externalStorage,
+        sdcardDirectory,
         mContext.getPackageName());
 
     String child = String.format("%s/screenshots-%s", parent, type);


### PR DESCRIPTION
A major issue with Firebase Test Lab is that it keeps pulling the screenshots from the `screenshots` directory and deleting them on the device, possibly to make sure it always has space for new stuff.

But that ends up corrupting the `metadata.xml` and in the case of my personal implementation, it corrupts the zip file I create containing all the screenshots.

This PR works around that by enabling the user to specify a directory other than `screenshots` directory. Regardless of Firebase, this is a decent feature to have.

I ran the `integration-tests` and `core:connectedAndroidTest` and both passed.

This is primarily intended to work with a disconnected workflow. So I don't really think Python tests are an issue.

This addresses issues #76 , #54 and #73 