### PR TITLE
Tasks support to include them in the tasks list of the project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /build
 repo
 examples/**/build
+examples/**/.idea/*
 .idea/*
 !.idea/codeStyleSettings.xml
 *.iml

--- a/core/src/main/java/com/facebook/testing/screenshot/internal/TestNameDetector.java
+++ b/core/src/main/java/com/facebook/testing/screenshot/internal/TestNameDetector.java
@@ -43,7 +43,7 @@ public class TestNameDetector {
         return UNKNOWN;
       }
     }
-    return "unknown";
+    return UNKNOWN;
   }
 
   /**

--- a/plugin/src/main/groovy/com/facebook/testing/screenshot/build/ScreenshotsPlugin.groovy
+++ b/plugin/src/main/groovy/com/facebook/testing/screenshot/build/ScreenshotsPlugin.groovy
@@ -13,6 +13,8 @@ class ScreenshotsPluginExtension {
     def referenceDir = ""
     def targetPackage = ""
 
+    def GROUP = "Screenshot"
+
     // Deprecated. We automatically detect adb now. Using this will
     // throw an error.
     @Deprecated
@@ -39,6 +41,8 @@ class ScreenshotsPlugin implements Plugin<Project> {
     }
 
     project.task('pullScreenshots') {
+      group = project.screenshots.GROUP
+      description = "Pull screenshots from the device"
       doLast {
         project.exec {
           def output = getTestApkOutput(project)
@@ -63,6 +67,8 @@ class ScreenshotsPlugin implements Plugin<Project> {
     }
 
     project.task('pullScreenshotsFromDirectory') {
+      group = project.screenshots.GROUP
+      description = "Pull screenshots from the device to specific folder"
       doLast {
         project.exec {
 
@@ -93,6 +99,8 @@ class ScreenshotsPlugin implements Plugin<Project> {
     }
 
     project.task("clearScreenshots") {
+      group = project.screenshots.GROUP
+      description = "Remove screenshots on the device"
       doLast {
         project.exec {
           executable = adb
@@ -104,7 +112,10 @@ class ScreenshotsPlugin implements Plugin<Project> {
 
     project.afterEvaluate {
       adb = project.android.getAdbExe().toString()
-      project.task("screenshotTests")
+      project.task("screenshotTests") {
+        group = project.screenshots.GROUP
+        description = "Run all the instrumentation tests, and then generate a report of all of the screenshots"
+      }
       project.screenshotTests.dependsOn project.clearScreenshots
       project.screenshotTests.dependsOn project.screenshots.connectedAndroidTestTarget
       project.screenshotTests.dependsOn project.pullScreenshots
@@ -119,12 +130,16 @@ class ScreenshotsPlugin implements Plugin<Project> {
     }
 
     project.task("recordMode") {
+      group = project.screenshots.GROUP
+      description = "Run all the screenshot tests and record all the screenshots in your screenshots folder"
       doLast {
         recordMode = true
       }
     }
 
     project.task("verifyMode") {
+      group = project.screenshots.GROUP
+      description = "Runs all the screenshot tests and compares it against the previously recorded screenshots"
       doLast {
         verifyMode = true
       }

--- a/plugin/src/main/groovy/com/facebook/testing/screenshot/build/ScreenshotsPlugin.groovy
+++ b/plugin/src/main/groovy/com/facebook/testing/screenshot/build/ScreenshotsPlugin.groovy
@@ -13,7 +13,7 @@ class ScreenshotsPluginExtension {
     def referenceDir = ""
     def targetPackage = ""
 
-    def GROUP = "Screenshot"
+    def GROUP = "Screenshot tests"
 
     // Deprecated. We automatically detect adb now. Using this will
     // throw an error.
@@ -68,7 +68,7 @@ class ScreenshotsPlugin implements Plugin<Project> {
 
     project.task('pullScreenshotsFromDirectory') {
       group = project.screenshots.GROUP
-      description = "Pull screenshots from the device to specific folder"
+      description = "Pull screenshots from the device to a specific folder"
       doLast {
         project.exec {
 
@@ -114,7 +114,7 @@ class ScreenshotsPlugin implements Plugin<Project> {
       adb = project.android.getAdbExe().toString()
       project.task("screenshotTests") {
         group = project.screenshots.GROUP
-        description = "Run all the instrumentation tests, and then generate a report of all of the screenshots"
+        description = "Run all screenshot tests and generate a report"
       }
       project.screenshotTests.dependsOn project.clearScreenshots
       project.screenshotTests.dependsOn project.screenshots.connectedAndroidTestTarget
@@ -131,7 +131,7 @@ class ScreenshotsPlugin implements Plugin<Project> {
 
     project.task("recordMode") {
       group = project.screenshots.GROUP
-      description = "Run all the screenshot tests and record all the screenshots in your screenshots folder"
+      description = "Run all screenshot tests and record all screenshots in your screenshots folder"
       doLast {
         recordMode = true
       }
@@ -139,7 +139,7 @@ class ScreenshotsPlugin implements Plugin<Project> {
 
     project.task("verifyMode") {
       group = project.screenshots.GROUP
-      description = "Runs all the screenshot tests and compares it against the previously recorded screenshots"
+      description = "Run all screenshot tests and compare them against previously recorded screenshots"
       doLast {
         verifyMode = true
       }


### PR DESCRIPTION
First time I used this library, I felt a bit lost in what gradle commands were available in the project.

In order to help users of the library to understand better which tasks are available for them regarding screenshot-tests-for-android, this pull request include project custom tasks into the tasks list output of the related  gradle command, example output:

$ ./gradlew tasks
 ...
 Screenshot tasks
 clearScreenshots - Remove screenshots on the device
 pullScreenshots - Pull screenshots from the device
 pullScreenshotsFromDirectory - Pull screenshots from the device to specific folder
 recordMode - Run all the screenshot tests and record all the screenshots in your screenshots folder
 screenshotTests - Run all the instrumentation tests, and then generate a report of all of the screenshots
 verifyMode - Runs all the screenshot tests and compares it against the previously recorded screenshots
 ...

I have included descriptions based on tasks behavior also descriptions extracted from the web, please feel free to change them to align better with the purpose of the task.