### PR TITLE
Spruce up Results Page

### DIFF
--- a/plugin/src/py/android_screenshot_tests/default.css
+++ b/plugin/src/py/android_screenshot_tests/default.css
@@ -1,5 +1,6 @@
 body {
-    background: #D3D3D3;
+    background: #fafafa;
+    font-family: 'Arial';
 }
 
 img {
@@ -8,10 +9,25 @@ img {
 
 .img-wrapper {
     background-image: url("background.png");
+    float:left;
+    margin-top: 16px;
+    margin-right: 16px;
 }
 
 .img-wrapper.dark {
     background-image: url("background_dark.png");
+}
+
+.command-wrapper {
+    margin-top: 16px;
+}
+
+.hierarchy {
+    background: #DDD;
+    padding: 16px;
+    max-height: 500px;
+    overflow: auto;
+    border-radius: 3px;
 }
 
 div.screenshot {
@@ -19,7 +35,7 @@ div.screenshot {
 }
 
 div.alternate {
-    background: #E0E0E0;
+
 }
 
 div.screenshot_error {
@@ -39,4 +55,48 @@ table, th, tr, td, img{
 table {
     border-spacing: 0;
     border-collapse: collapse;
+}
+
+.screenshot_name {
+    font-size: 24px;
+}
+
+.screenshot_name .demphasize {
+    color: #999;
+}
+
+.screenshot_description {
+    color: #999;
+    font-style: italic;
+}
+
+button {
+    border: 1px solid #000;
+    border-radius: 3px;
+    background-color: #fff;
+    padding: 16px;
+    font-size: 18px;
+}
+
+button:hover {
+    background-color: #000;
+    color: #fff;
+    cursor: pointer;
+}
+
+.clearfix {
+    display: block;
+    clear: both;
+    content: "";
+}
+
+hr {
+    border: 0;
+    height: 1px;
+    background-color: #000;
+    margin: 16px 0;
+}
+
+h3 {
+    font-weight: normal;
 }

--- a/plugin/src/py/android_screenshot_tests/default.js
+++ b/plugin/src/py/android_screenshot_tests/default.js
@@ -1,20 +1,4 @@
 $(function () {
-    $(".view_dump").click(function () {
-        var name = $(this).attr('data-name');
-        $.ajax(
-            {
-                url: name + "_dump.xml",
-                dataType: "text",
-                success: function(result) {
-                    window.alert(result);
-                },
-                error: function(result) {
-                    window.alert("could not load the view hierarchy for " + name);
-                }
-            });
-
-    });
-
     $(".extra").click(function () {
             var str = $(this).attr('data');
             $('<pre></pre>').dialog({

--- a/plugin/src/py/android_screenshot_tests/pull_screenshots.py
+++ b/plugin/src/py/android_screenshot_tests/pull_screenshots.py
@@ -52,6 +52,7 @@ def generate_html(dir):
         html.write('<!DOCTYPE html>')
         html.write('<html>')
         html.write('<head>')
+        html.write('<title>Screenshot Test Results</title>')
         html.write('<script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>')
         html.write('<script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.11.3/jquery-ui.min.js"></script>')
         html.write('<script src="default.js"></script>')
@@ -59,19 +60,20 @@ def generate_html(dir):
         html.write('<link rel="stylesheet" href="default.css"></head>')
         html.write('<body>')
 
-        html.write('<!-- begin results -->')
-
         for screenshot in sort_screenshots(root.iter('screenshot')):
             alternate = not alternate
+            canonical_name = screenshot.find('name').text
+            last_seperator = canonical_name.rindex('.') + 1
+            package = canonical_name[:last_seperator]
+            name = canonical_name[last_seperator:]
             html.write('<div class="screenshot %s">' % ('alternate' if alternate else ''))
-            html.write('<div class="screenshot_name">%s</div>' % (screenshot.find('name').text))
+            html.write('<div class="screenshot_name">')
+            html.write('<span class="demphasize">%s</span>%s' % (package, name))
+            html.write('</div>')
 
             group = screenshot.find('group')
-
             if group:
                 html.write('<div class="screenshot_group">%s</div>' % group.text)
-
-            html.write('<button class="view_dump" data-name="%s">Dump view hierarchy</button>' % (screenshot.find('name').text))
 
             extras = screenshot.find('extras')
             if extras is not None:
@@ -91,13 +93,26 @@ def generate_html(dir):
             if error is not None:
                 html.write('<div class="screenshot_error">%s</div>' % error.text)
             else:
-                html.write('<button class="toggle_dark">Toggle dark background</button>')
                 write_image(dir, html, screenshot)
+                write_commands(dir, html, screenshot)
 
             html.write('</div>')
+            html.write('<div class="clearfix"></div>')
+            html.write('<hr/>')
 
         html.write('</body></html>')
         return index_html
+
+def write_commands(dir, html, screenshot):
+    html.write('<div class="command-wrapper">')
+    html.write('<button class="toggle_dark">Toggle dark background</button>')
+    html.write('<hr/>')
+    html.write('<h3>View Hierarchy</h3>')
+    html.write('<pre class="hierarchy">')
+    with open(join(dir, screenshot.find('name').text + "_dump.xml"), "r") as xml:
+        html.write(xml.read().replace("<", "&lt;").replace(">", "&gt;"))
+    html.write('</pre>')
+    html.write('</div>')
 
 def write_image(dir, html, screenshot):
     html.write('<table class="img-wrapper">')


### PR DESCRIPTION
The screenshot test result page looked a little sad / bland before, this
makes it look better (tm). I also inlined the view hierarchy since the
previous button to view it didnt work, and it didnt make much sense not
to. I also plan on converting the XML into a collapsable hierarchy at
some point, but this is a quick start on a redesign of the page

![image](https://user-images.githubusercontent.com/993832/31147176-ff8a53bc-a856-11e7-88f6-d412f6c48d8f.png)
