### PR TITLE
Make dark background toggle more robust

### DIFF
--- a/plugin/src/py/android_screenshot_tests/default.js
+++ b/plugin/src/py/android_screenshot_tests/default.js
@@ -20,6 +20,6 @@ $(function () {
         });
 
     $(".toggle_dark").click(function() {
-        var image_wrapper = $(this).siblings(".img-wrapper").toggleClass("dark");
+        var image_wrapper = $(this).closest(".screenshot").find(".img-wrapper").toggleClass("dark")
     })
 });


### PR DESCRIPTION
I previously broke this button due to changing the HTML, this makes
the JS function more robust such that it hopefully doesn't easily
break in the future