### PR TITLE
Exclude BUCK files on androidJavadoc gradle task

### DIFF
--- a/release.gradle
+++ b/release.gradle
@@ -78,7 +78,7 @@ if (property('POM_PACKAGING') == 'aar') {
     task androidJavadoc(type: Javadoc) {
         source = android.sourceSets.main.java.srcDirs
         classpath += files(android.bootClasspath)
-        exclude "com/facebook/testing/screenshot/BUCK"
+        exclude "**/BUCK"
 
         project.android.libraryVariants.all { variant ->
           if (variant.name == "release") {

--- a/release.gradle
+++ b/release.gradle
@@ -78,6 +78,7 @@ if (property('POM_PACKAGING') == 'aar') {
     task androidJavadoc(type: Javadoc) {
         source = android.sourceSets.main.java.srcDirs
         classpath += files(android.bootClasspath)
+        exclude "com/facebook/testing/screenshot/BUCK"
 
         project.android.libraryVariants.all { variant ->
           if (variant.name == "release") {


### PR DESCRIPTION
# I can't install it in my maven local

### Fix java doc task

After running ./gradlew installAll, gradle androidJavadoc task returns an error because BUCK files cannot be parsed in this task.
Error output:
```
> Task :core:androidJavadoc
javadoc: error - Illegal package name: "/home/josedlpozo/workspace/screenshot-tests-for-android/core/src/main/java/com/facebook/testing/screenshot/BUCK"
1 error


FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':core:androidJavadoc'.
> Javadoc generation failed. Generated Javadoc options file (useful for troubleshooting): '/home/josedlpozo/workspace/screenshot-tests-for-android/core/build/tmp/androidJavadoc/javadoc.options'
```

### How is it fixed?
BUCK file inside core library is excluded