### PR TITLE
Add param for custom python executable

### DIFF
--- a/plugin/src/main/groovy/com/facebook/testing/screenshot/build/ScreenshotsPlugin.groovy
+++ b/plugin/src/main/groovy/com/facebook/testing/screenshot/build/ScreenshotsPlugin.groovy
@@ -9,6 +9,8 @@ class ScreenshotsPluginExtension {
     def recordDir = "screenshots"
     def addCompileDeps = true
 
+    def pythonExecutable = "python"
+
     // Only used for the pullScreenshotsFromDirectory task
     def referenceDir = ""
     def targetPackage = ""
@@ -47,7 +49,7 @@ class ScreenshotsPlugin implements Plugin<Project> {
         project.exec {
           def output = getTestApkOutput(project)
 
-          executable = 'python'
+          executable = project.screenshots.pythonExecutable
           environment('PYTHONPATH', jarFile)
 
           args = ['-m', 'android_screenshot_tests.pull_screenshots', "--apk", output.toString()]
@@ -72,7 +74,7 @@ class ScreenshotsPlugin implements Plugin<Project> {
       doLast {
         project.exec {
 
-          executable = 'python'
+          executable = project.screenshots.pythonExecutable
           environment('PYTHONPATH', jarFile)
 
           def referenceDir = project.screenshots.referenceDir


### PR DESCRIPTION
I added gradle extension param for passing custom python executable path, because on some machines python is python3 link.