### PR TITLE
Consolidate dependencies and versions to one file

### DIFF
--- a/.idea/codeStyleSettings.xml
+++ b/.idea/codeStyleSettings.xml
@@ -60,10 +60,15 @@
           </extensions>
         </Objective-C-extensions>
         <XML>
-          <option name="XML_KEEP_LINE_BREAKS" value="false" />
-          <option name="XML_ALIGN_ATTRIBUTES" value="false" />
-          <option name="XML_SPACE_INSIDE_EMPTY_TAG" value="true" />
+          <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />
         </XML>
+        <codeStyleSettings language="Groovy">
+          <indentOptions>
+            <option name="INDENT_SIZE" value="2" />
+            <option name="CONTINUATION_INDENT_SIZE" value="4" />
+            <option name="TAB_SIZE" value="2" />
+          </indentOptions>
+        </codeStyleSettings>
         <codeStyleSettings language="JAVA">
           <option name="KEEP_BLANK_LINES_IN_DECLARATIONS" value="1" />
           <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="0" />
@@ -76,7 +81,9 @@
         <codeStyleSettings language="XML">
           <option name="FORCE_REARRANGE_MODE" value="1" />
           <indentOptions>
-            <option name="CONTINUATION_INDENT_SIZE" value="4" />
+            <option name="INDENT_SIZE" value="2" />
+            <option name="CONTINUATION_INDENT_SIZE" value="2" />
+            <option name="TAB_SIZE" value="2" />
           </indentOptions>
           <arrangement>
             <rules>

--- a/build.gradle
+++ b/build.gradle
@@ -1,34 +1,40 @@
 buildscript {
-    repositories {
-      mavenCentral()
-    }
+  apply from: rootProject.file('versions.gradle')
+  repositories {
+    mavenCentral()
+  }
 }
 
 allprojects {
   version = property('VERSION_NAME')
+  repositories {
+    jcenter()
+    maven {
+      url "https://maven.google.com"
+    }
+  }
 }
 
 task uploadAllLocal(dependsOn: [
-     ":plugin:uploadArchives",
-     ":core:uploadArchives"]) {
+    ":plugin:uploadArchives",
+    ":core:uploadArchives"]) {
 }
 
 task installAll(dependsOn: [
-     ":core:install",
-     ":plugin:install",
+    ":core:install",
+    ":plugin:install",
 ])
 
 task uploadAllArchives(dependsOn:
-                    [":plugin:uploadArchives",
-                     ":core:uploadArchives"]) {
-    doLast {
-        println("You need to close and release this from 'Staging Repositories' in http://oss.sonatype.org");
-    }
+    [":plugin:uploadArchives",
+     ":core:uploadArchives"]) {
+  doLast {
+    println("You need to close and release this from 'Staging Repositories' in http://oss.sonatype.org");
+  }
 }
-
 
 // Run all the tests prior to release. Also run integration_test.sh
 task releaseTests(dependsOn:
-                  [":plugin:pyTests",
-                   ":plugin:test",
-                   ":core:connectedAndroidTest"])
+    [":plugin:pyTests",
+     ":plugin:test",
+     ":core:connectedAndroidTest"])

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -1,66 +1,60 @@
 buildscript {
-    repositories {
-        jcenter()
-        mavenCentral()
-    }
+  repositories {
+    jcenter()
+    mavenCentral()
+  }
 
-    dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
-
-        // Can't use the default maven install for android libraries
-        classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
-    }
+  dependencies {
+    classpath plugs.agp
+    classpath plugs.mavenGradle
+  }
 }
 
 apply plugin: 'com.android.library'
 apply plugin: 'com.github.dcendents.android-maven'
 
-group='com.facebook.testing.screenshot'
+group = 'com.facebook.testing.screenshot'
 
 repositories {
   mavenCentral()
 }
 
 dependencies {
-    compile 'junit:junit:4.12'
-    compile 'com.crittercism.dexmaker:dexmaker:1.4'
-    compile 'com.crittercism.dexmaker:dexmaker-dx:1.4'
+  compile deps.dexmaker
+  compile deps.dexmakerDx
+  compile deps.junit
 
-    androidTestCompile 'org.mockito:mockito-core:1.10.19'
-    androidTestCompile 'com.crittercism.dexmaker:dexmaker-mockito:1.4'
-    androidTestCompile 'com.android.support:support-v4:23.1.1'
-    androidTestCompile 'com.android.support.test:rules:0.5'
-    androidTestCompile 'com.android.support.test.espresso:espresso-core:2.2.2'
+  androidTestCompile deps.espresso
+  androidTestCompile deps.mockito
+  androidTestCompile deps.dexmakerMockito
+  androidTestCompile deps.hamcrest
 }
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '26.0.1'
+  compileSdkVersion versions.compileSdk
+  buildToolsVersion versions.buildTools
 
-    packagingOptions {
-        exclude 'LICENSE.txt'
-    }
+  packagingOptions {
+    exclude 'LICENSE.txt'
+  }
 
-    defaultConfig {
-        minSdkVersion 9
-        targetSdkVersion 25
-        testInstrumentationRunner "com.facebook.testing.screenshot.CustomScreenshotTestRunner"
-    }
+  defaultConfig {
+    minSdkVersion versions.minSdk
+    targetSdkVersion versions.targetSdk
+    testInstrumentationRunner "com.facebook.testing.screenshot.CustomScreenshotTestRunner"
+  }
 
-    lintOptions {
-        abortOnError false
-        disable 'InvalidPackage'
-    }
-
-    sourceSets {
-    }
+  lintOptions {
+    abortOnError false
+    disable 'InvalidPackage'
+  }
 }
 
 uploadArchives {
-    repositories {
-        mavenInstaller {
-        }
+  repositories {
+    mavenInstaller {
     }
+  }
 }
 
 apply from: rootProject.file("release.gradle")

--- a/core/src/androidTest/AndroidManifest.xml
+++ b/core/src/androidTest/AndroidManifest.xml
@@ -1,15 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.facebook.testing.screenshot.tests">
-  <uses-sdk android:minSdkVersion='9' android:targetSdkVersion='14'/>
-  <uses-permission
-      android:name="android.permission.DISABLE_KEYGUARD"/>
-  <uses-permission android:name="android.permission.SET_ANIMATION_SCALE" />
+<!--
+ Copyright (c) 2014-present, Facebook, Inc.
+ All rights reserved.
 
-  <application
-      android:debuggable="true">
-      <activity
-          android:name="com.facebook.testing.screenshot.MyActivity" />
-    </application>
+ This source code is licensed under the license found in the
+ LICENSE-examples file in the root directory of this source tree.
+-->
+<manifest
+  xmlns:android="http://schemas.android.com/apk/res/android"
+  package="com.facebook.testing.screenshot.tests">
+
+  <uses-permission android:name="android.permission.DISABLE_KEYGUARD"/>
+  <uses-permission android:name="android.permission.SET_ANIMATION_SCALE"/>
+
+  <application android:debuggable="true">
+    <activity android:name="com.facebook.testing.screenshot.MyActivity"/>
+  </application>
 </manifest>

--- a/core/src/main/AndroidManifest.xml
+++ b/core/src/main/AndroidManifest.xml
@@ -1,7 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+ Copyright (c) 2014-present, Facebook, Inc.
+ All rights reserved.
+
+ This source code is licensed under the license found in the
+ LICENSE-examples file in the root directory of this source tree.
+-->
 <manifest
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.facebook.testing.screenshot">
-   <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
-   <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+  xmlns:android="http://schemas.android.com/apk/res/android"
+  package="com.facebook.testing.screenshot">
+
+  <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
+  <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
 </manifest>

--- a/examples/app-example-androidjunitrunner/app/build.gradle
+++ b/examples/app-example-androidjunitrunner/app/build.gradle
@@ -4,35 +4,32 @@ apply plugin: 'com.facebook.testing.screenshot'
 project.screenshots.customTestRunner = true
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "26.0.1"
-    defaultConfig {
-
-        multiDexEnabled true
-        applicationId "com.example.screenshots"
-        minSdkVersion 15
-        targetSdkVersion 25
-        versionCode 1
-        versionName "1.0"
-        testInstrumentationRunner "com.example.screenshots.CustomTestRunner"
+  compileSdkVersion versions.compileSdk
+  buildToolsVersion versions.buildTools
+  defaultConfig {
+    multiDexEnabled true
+    applicationId "com.example.screenshots"
+    minSdkVersion 15
+    targetSdkVersion versions.targetSdk
+    versionCode 1
+    versionName "1.0"
+    testInstrumentationRunner "com.example.screenshots.CustomTestRunner"
+  }
+  buildTypes {
+    release {
+      minifyEnabled false
+      proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
     }
-    buildTypes {
-        release {
-            minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
-        }
-    }
-
+  }
 }
 
-
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
-        exclude group: 'com.android.support', module: 'support-annotations'
-    })
-    compile 'com.android.support:appcompat-v7:25.1.0'
-    compile 'com.android.support:design:25.1.0'
-    compile 'com.android.support:multidex:1.0.1'
-    testCompile 'junit:junit:4.12'
+  compile deps.supportAppCompat
+  compile deps.supportDesign
+  compile deps.supportMultidex
+
+  androidTestCompile deps.junit
+  androidTestCompile(deps.espresso) {
+    exclude group: 'com.android.support', module: 'support-annotations'
+  }
 }

--- a/examples/app-example-androidjunitrunner/app/src/main/AndroidManifest.xml
+++ b/examples/app-example-androidjunitrunner/app/src/main/AndroidManifest.xml
@@ -1,24 +1,32 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.example.screenshots">
+<!--
+ Copyright (c) 2014-present, Facebook, Inc.
+ All rights reserved.
 
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
-    <application
-        android:allowBackup="true"
-        android:icon="@mipmap/ic_launcher"
-        android:label="@string/app_name"
-        android:supportsRtl="true"
-        android:theme="@style/AppTheme">
-        <activity
-            android:name=".MainActivity"
-            android:label="@string/app_name"
-            android:theme="@style/AppTheme.NoActionBar">
-            <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
+ This source code is licensed under the license found in the
+ LICENSE-examples file in the root directory of this source tree.
+-->
+<manifest
+  xmlns:android="http://schemas.android.com/apk/res/android"
+  package="com.example.screenshots">
 
-                <category android:name="android.intent.category.LAUNCHER" />
-            </intent-filter>
-        </activity>
-    </application>
+  <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
+  <application
+    android:allowBackup="true"
+    android:icon="@mipmap/ic_launcher"
+    android:label="@string/app_name"
+    android:supportsRtl="true"
+    android:theme="@style/AppTheme">
+    <activity
+      android:name=".MainActivity"
+      android:label="@string/app_name"
+      android:theme="@style/AppTheme.NoActionBar">
+      <intent-filter>
+        <action android:name="android.intent.action.MAIN"/>
+
+        <category android:name="android.intent.category.LAUNCHER"/>
+      </intent-filter>
+    </activity>
+  </application>
 
 </manifest>

--- a/examples/app-example-androidjunitrunner/build.gradle
+++ b/examples/app-example-androidjunitrunner/build.gradle
@@ -1,25 +1,27 @@
-// Top-level build file where you can add configuration options common to all sub-projects/modules.
-
 buildscript {
-    repositories {
-        mavenLocal()
-        jcenter()
-    }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
-        classpath 'com.facebook.testing.screenshot:plugin:0.4.4'
-        // NOTE: Do not place your application dependencies here; they belong
-        // in the individual module build.gradle files
-    }
+  apply from: rootProject.file('../../versions.gradle')
+
+  repositories {
+    mavenLocal()
+    jcenter()
+  }
+
+  dependencies {
+    classpath plugs.agp
+    classpath plugs.screenshot
+  }
 }
 
 allprojects {
-    repositories {
-        mavenLocal()
-        jcenter()
+  repositories {
+    mavenLocal()
+    jcenter()
+    maven {
+      url "https://maven.google.com"
     }
+  }
 }
 
 task clean(type: Delete) {
-    delete rootProject.buildDir
+  delete rootProject.buildDir
 }

--- a/examples/app-example/build.gradle
+++ b/examples/app-example/build.gradle
@@ -1,36 +1,36 @@
 buildscript {
-    repositories {
-        mavenLocal()
-        mavenCentral()
-        jcenter()
-    }
+  apply from: rootProject.file('../../versions.gradle')
 
-    dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
-        classpath 'com.facebook.testing.screenshot:plugin:0.4.4'
-    }
+  repositories {
+    mavenLocal()
+    jcenter()
+  }
+
+  dependencies {
+    classpath plugs.agp
+    classpath plugs.screenshot
+  }
 }
 
 apply plugin: 'com.android.application'
 apply plugin: 'com.facebook.testing.screenshot'
 
-repositories {
+allprojects {
+  repositories {
     mavenLocal()
-    mavenCentral()
+    jcenter()
+    maven {
+      url "https://maven.google.com"
+    }
+  }
 }
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "26.0.1"
+  compileSdkVersion versions.compileSdk
+  buildToolsVersion versions.buildTools
 
-    defaultConfig {
-        minSdkVersion 9
-        targetSdkVersion 25
-    }
-
-    sourceSets {
-    }
-}
-
-dependencies {
+  defaultConfig {
+    minSdkVersion 9
+    targetSdkVersion versions.targetSdk
+  }
 }

--- a/examples/app-example/src/main/AndroidManifest.xml
+++ b/examples/app-example/src/main/AndroidManifest.xml
@@ -7,11 +7,12 @@
  LICENSE-examples file in the root directory of this source tree.
 -->
 <manifest
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    package='com.facebook.testing.screenshot.examples'>
-   <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
-   <application>
-     <!-- not having an empty application block seems to cause the
-          instrumentation tests to fail with a ClassNotFoundException . -->
-   </application>
+  xmlns:android="http://schemas.android.com/apk/res/android"
+  package='com.facebook.testing.screenshot.examples'>
+
+  <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
+  <application>
+    <!-- not having an empty application block seems to cause the
+         instrumentation tests to fail with a ClassNotFoundException . -->
+  </application>
 </manifest>

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'groovy'
 jar {
-    manifest {
-        attributes "Implementation-Version": project.version.toString()
-    }
+  manifest {
+    attributes "Implementation-Version": project.version.toString()
+  }
 }
 
 apply plugin: 'maven'
@@ -13,51 +13,51 @@ repositories {
 }
 
 dependencies {
-    compile gradleApi()
-    compile group: 'org.eclipse.jetty', name: 'jetty-server', version: '9.3.10.v20160621'
+  compile gradleApi()
+  compile group: 'org.eclipse.jetty', name: 'jetty-server', version: '9.3.10.v20160621'
 
-    testCompile 'junit:junit:4.12'
-    testCompile group: 'org.mockito', name: 'mockito-all', version: '1.9.5'
-    testCompile 'com.android.tools.build:gradle:2.3.3'
-    testCompile 'org.hamcrest:hamcrest-all:1.3'
+  testCompile deps.junit
+  testCompile plugs.agp
+  testCompile deps.mockito
+  testCompile deps.hamcrest
 }
 
-group='com.facebook.testing.screenshot'
+group = 'com.facebook.testing.screenshot'
 
 uploadArchives {
-    repositories {
-        mavenInstaller {
-        }
+  repositories {
+    mavenInstaller {
     }
+  }
 }
 
 compileJava {
-    sourceSets {
-      main {
-         resources.srcDirs 'src/py'
-         resources {
-             exclude '**/*.pyc'
-             exclude '**/test_*.py'
-             exclude '**/fixtures/**'
-         }
+  sourceSets {
+    main {
+      resources.srcDirs 'src/py'
+      resources {
+        exclude '**/*.pyc'
+        exclude '**/test_*.py'
+        exclude '**/fixtures/**'
       }
     }
+  }
 }
 
 task pyTests(type: Exec) {
-     workingDir file('./src/py')
-     commandLine 'python', '-m', 'unittest', 'discover'
+  workingDir file('./src/py')
+  commandLine 'python', '-m', 'unittest', 'discover'
 }
 
 task py3Tests(type: Exec) {
-     workingDir file('./src/py')
-     commandLine 'python3', '-m', 'unittest', 'discover'
+  workingDir file('./src/py')
+  commandLine 'python3', '-m', 'unittest', 'discover'
 }
 
 task sampleServer() {
-    doLast {
-        file = new File("plugin/src/py/android_screenshot_tests/fixtures/sdcard/screenshots/com.foo/screenshots-default/metadata.xml")
-    }
+  doLast {
+    file = new File("plugin/src/py/android_screenshot_tests/fixtures/sdcard/screenshots/com.foo/screenshots-default/metadata.xml")
+  }
 }
 
 apply from: rootProject.file("release.gradle")

--- a/plugin/src/test/groovy/com/facebook/testing/screenshot/build/ScreenshotsPluginTest.groovy
+++ b/plugin/src/test/groovy/com/facebook/testing/screenshot/build/ScreenshotsPluginTest.groovy
@@ -4,7 +4,7 @@ import org.junit.*
 import static org.junit.Assert.*
 import org.gradle.api.*
 import org.gradle.testfixtures.*
-import static org.hamcrest.Matchers.*
+import static org.hamcrest.CoreMatchers.*
 
 class ScreenshotsPluginForTest extends ScreenshotsPlugin {
   static public runtimeDepAdded = false

--- a/versions.gradle
+++ b/versions.gradle
@@ -1,0 +1,32 @@
+ext {
+  versions = [
+      targetSdk : 26,
+      compileSdk: 26,
+      minSdk    : 9,
+      buildTools: '26.0.1',
+  ]
+
+  plugs = [
+      "agp"        : "com.android.tools.build:gradle:2.3.3",
+      "mavenGradle": "com.github.dcendents:android-maven-gradle-plugin:1.5",
+      "screenshot" : "com.facebook.testing.screenshot:plugin:0.4.4",
+  ]
+
+  final supportLibraryVersion = '26.0.2'
+  final dexmakerVersion = "1.4"
+
+  deps = [
+      supportAppCompat : "com.android.support:appcompat-v7:$supportLibraryVersion",
+      supportDesign    : "com.android.support:design:$supportLibraryVersion",
+      supportMultidex  : "com.android.support:multidex:1.0.1",
+
+      "dexmaker"       : "com.crittercism.dexmaker:dexmaker:$dexmakerVersion",
+      "dexmakerDx"     : "com.crittercism.dexmaker:dexmaker-dx:$dexmakerVersion",
+      "dexmakerMockito": "com.crittercism.dexmaker:dexmaker-mockito:$dexmakerVersion",
+
+      "espresso"       : "com.android.support.test.espresso:espresso-core:3.0.1",
+      "junit"          : "junit:junit:4.12",
+      "mockito"        : "org.mockito:mockito-core:1.10.19",
+      "hamcrest"       : "org.hamcrest:hamcrest-core:1.3",
+  ]
+}


### PR DESCRIPTION
We now have a versions.gradle  that is the one place to modify dependency versions, instead of manually modifying several gradle files. In addition to that, I've formatted each gradle file and added missing copyright notices. 

make release-tests passes.