### PR TITLE
Change Highlighter to Rouge

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -9,7 +9,7 @@ ghrepo: "facebook/screenshot-tests-for-android"
 
 # Build settings
 markdown: redcarpet
-highlighter: pygments
+highlighter: rouge
 lsi: false
 
 exclude: [README.md, Gemfile, scripts, vendor]


### PR DESCRIPTION
GitHub exclusively utilizes the Rouge highlighter. This will
prevent GitHub from continually sending warning emails
about it