### PR TITLE
Remove runtime dependency on Dex maker

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -24,8 +24,8 @@ android {
 }
 
 dependencies {
-  api deps.dexmaker
-  api deps.dexmakerDx
+  androidTestApi deps.dexmaker
+  androidTestApi deps.dexmakerDx
 
   androidTestApi deps.espresso
   androidTestApi deps.mockito


### PR DESCRIPTION
View$AttachInfo$Callbacks is an interface seemingly from API 9 onwards
so there's no need to use dex maker to proxy the class.

This removes the dependency for the runtime library, tests still need it
for mockito stuff.

Fixes #152