### PR TITLE
Replace androidTestApi configuration with androidTestImplementation

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -40,13 +40,13 @@ android {
 }
 
 dependencies {
-  androidTestApi deps.dexmaker
-  androidTestApi deps.dexmakerDx
+  androidTestImplementation deps.dexmaker
+  androidTestImplementation deps.dexmakerDx
 
-  androidTestApi deps.espresso
-  androidTestApi deps.mockito
-  androidTestApi deps.dexmakerMockito
-  androidTestApi deps.hamcrest
+  androidTestImplementation deps.espresso
+  androidTestImplementation deps.mockito
+  androidTestImplementation deps.dexmakerMockito
+  androidTestImplementation deps.hamcrest
 }
 
 uploadArchives {

--- a/layout-hierarchy-common/build.gradle
+++ b/layout-hierarchy-common/build.gradle
@@ -37,7 +37,7 @@ android {
 dependencies {
   implementation project(':core')
 
-  androidTestApi deps.espresso
+  androidTestImplementation deps.espresso
 }
 
 uploadArchives {

--- a/layout-hierarchy-litho/build.gradle
+++ b/layout-hierarchy-litho/build.gradle
@@ -39,7 +39,7 @@ dependencies {
   implementation deps.lithoCore
   implementation deps.lithoWidget
 
-  androidTestApi deps.espresso
+  androidTestImplementation deps.espresso
 }
 
 uploadArchives {

--- a/plugin/src/main/kotlin/com/facebook/testing/screenshot/build/ScreenshotsPlugin.kt
+++ b/plugin/src/main/kotlin/com/facebook/testing/screenshot/build/ScreenshotsPlugin.kt
@@ -49,7 +49,7 @@ class ScreenshotsPlugin : Plugin<Project> {
     screenshotExtensions = extensions.create("screenshots", ScreenshotsPluginExtension::class.java)
 
     if (screenshotExtensions.addDeps) {
-      project.dependencies.add("androidTestApi", "$DEPENDENCY_GROUP:$DEPENDENCY_CORE:${ScreenshotTestBuildConfig.VERSION}")
+      project.dependencies.add("androidTestImplementation", "$DEPENDENCY_GROUP:$DEPENDENCY_CORE:${ScreenshotTestBuildConfig.VERSION}")
     }
 
     val variants = when {

--- a/plugin/src/test/groovy/com/facebook/testing/screenshot/build/ScreenshotsPluginTest.groovy
+++ b/plugin/src/test/groovy/com/facebook/testing/screenshot/build/ScreenshotsPluginTest.groovy
@@ -60,7 +60,7 @@ class ScreenshotsPluginTest {
 
   @Test
   void "Ensure core dependency added"() {
-    def depSet = project.getConfigurations().getByName('androidTestApi').getAllDependencies()
+    def depSet = project.getConfigurations().getByName('androidTestImplementation').getAllDependencies()
     for (dep in depSet) {
       if (dep.name == "core" && dep.group == 'com.facebook.testing.screenshot') {
         return


### PR DESCRIPTION
Recent versions of the Android Gradle Plugin print the following warning during a Gradle sync:

`Configuration 'androidTestApi' is obsolete and has been replaced
with 'androidTestImplementation'.`

This commit updates Gradle scripts, the plugin and a test to the recommended configuration.