### PR TITLE
Always use the same output directory for reports

### DIFF
--- a/plugin/src/main/kotlin/com/facebook/testing/screenshot/build/CleanScreenshotsTask.kt
+++ b/plugin/src/main/kotlin/com/facebook/testing/screenshot/build/CleanScreenshotsTask.kt
@@ -31,13 +31,9 @@ open class CleanScreenshotsTask : ScreenshotTask() {
     group = ScreenshotsPlugin.GROUP
   }
 
-  override fun init(variant: TestVariant, extension: ScreenshotsPluginExtension) {
-    super.init(variant, extension)
-  }
-
   @TaskAction
   fun cleanScreenshots() {
-      val outputDir = File(project.buildDir, "screenshots" + variant.name.capitalize()).getAbsolutePath()
-      project.delete(outputDir)
+    val outputDir = PullScreenshotsTask.getReportDir(project, variant)
+    project.delete(outputDir)
   }
 }

--- a/plugin/src/main/kotlin/com/facebook/testing/screenshot/build/CleanScreenshotsTask.kt
+++ b/plugin/src/main/kotlin/com/facebook/testing/screenshot/build/CleanScreenshotsTask.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2014-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.testing.screenshot.build
+
+import com.android.build.gradle.api.ApkVariantOutput
+import com.android.build.gradle.api.TestVariant
+import org.gradle.api.tasks.TaskAction
+import java.io.File
+
+
+open class CleanScreenshotsTask : ScreenshotTask() {
+  companion object {
+    fun taskName(variant: TestVariant) = "clean${variant.name.capitalize()}Screenshots"
+  }
+
+  init {
+    description = "Clean last generated screenshot report"
+    group = ScreenshotsPlugin.GROUP
+  }
+
+  override fun init(variant: TestVariant, extension: ScreenshotsPluginExtension) {
+    super.init(variant, extension)
+  }
+
+  @TaskAction
+  fun cleanScreenshots() {
+      val outputDir = File(project.buildDir, "screenshots" + variant.name.capitalize()).getAbsolutePath()
+      project.delete(outputDir)
+  }
+}

--- a/plugin/src/main/kotlin/com/facebook/testing/screenshot/build/PullScreenshotsTask.kt
+++ b/plugin/src/main/kotlin/com/facebook/testing/screenshot/build/PullScreenshotsTask.kt
@@ -18,12 +18,16 @@ package com.facebook.testing.screenshot.build
 import com.android.build.gradle.api.ApkVariantOutput
 import com.android.build.gradle.api.TestVariant
 import org.gradle.api.tasks.TaskAction
+import org.gradle.api.Project
 import java.io.File
 
 
 open class PullScreenshotsTask : ScreenshotTask() {
   companion object {
-    fun taskName(variant: TestVariant) = "pull${variant.name.capitalize()}Screenshots"
+      fun taskName(variant: TestVariant) = "pull${variant.name.capitalize()}Screenshots"
+
+      fun getReportDir(project: Project, variant: TestVariant): File =
+          File(project.buildDir, "screenshots" + variant.name.capitalize())
   }
 
   private lateinit var apkPath: File
@@ -44,7 +48,7 @@ open class PullScreenshotsTask : ScreenshotTask() {
   fun pullScreenshots() {
     val codeSource = ScreenshotsPlugin::class.java.protectionDomain.codeSource
     val jarFile = File(codeSource.location.toURI().path)
-    val outputDir = File(project.buildDir, "screenshots" + variant.name.capitalize())
+    val outputDir = getReportDir(project, variant)
 
     assert(!outputDir.exists())
 

--- a/plugin/src/main/kotlin/com/facebook/testing/screenshot/build/PullScreenshotsTask.kt
+++ b/plugin/src/main/kotlin/com/facebook/testing/screenshot/build/PullScreenshotsTask.kt
@@ -44,6 +44,9 @@ open class PullScreenshotsTask : ScreenshotTask() {
   fun pullScreenshots() {
     val codeSource = ScreenshotsPlugin::class.java.protectionDomain.codeSource
     val jarFile = File(codeSource.location.toURI().path)
+    val outputDir = File(project.buildDir, "screenshots" + variant.name.capitalize())
+
+    assert(!outputDir.exists())
 
     project.exec {
       it.executable = "python"
@@ -53,7 +56,9 @@ open class PullScreenshotsTask : ScreenshotTask() {
         "-m",
         "android_screenshot_tests.pull_screenshots",
         "--apk",
-        apkPath.absolutePath
+        apkPath.absolutePath,
+        "--temp-dir",
+        outputDir.absolutePath
       ).apply {
         if (verify) {
           add("--verify")

--- a/plugin/src/main/kotlin/com/facebook/testing/screenshot/build/ScreenshotTask.kt
+++ b/plugin/src/main/kotlin/com/facebook/testing/screenshot/build/ScreenshotTask.kt
@@ -20,8 +20,10 @@ import org.gradle.api.DefaultTask
 
 open class ScreenshotTask : DefaultTask() {
   protected lateinit var extension: ScreenshotsPluginExtension
+  protected lateinit var variant: TestVariant
 
   open fun init(variant: TestVariant, extension: ScreenshotsPluginExtension) {
-    this.extension = extension
+      this.extension = extension
+      this.variant = variant
   }
 }

--- a/plugin/src/main/kotlin/com/facebook/testing/screenshot/build/ScreenshotsPlugin.kt
+++ b/plugin/src/main/kotlin/com/facebook/testing/screenshot/build/ScreenshotsPlugin.kt
@@ -71,11 +71,19 @@ class ScreenshotsPlugin : Plugin<Project> {
   private fun generateTasksFor(project: Project, variant: TestVariant) {
     variant.outputs.all {
       if (it is ApkVariantOutput) {
+        val cleanScreenshots =createTask(
+            project,
+            CleanScreenshotsTask.taskName(variant),
+            variant,
+            CleanScreenshotsTask::class.java)
+        project.tasks.getByName("clean")
+            .dependsOn(cleanScreenshots)
+
         createTask(
             project,
             PullScreenshotsTask.taskName(variant),
             variant,
-            PullScreenshotsTask::class.java)
+            PullScreenshotsTask::class.java).dependsOn(cleanScreenshots)
 
         createTask(
             project,
@@ -93,7 +101,8 @@ class ScreenshotsPlugin : Plugin<Project> {
             project,
             VerifyScreenshotTestTask.taskName(variant),
             variant,
-            VerifyScreenshotTestTask::class.java)
+                VerifyScreenshotTestTask::class.java)
+
       }
     }
   }

--- a/plugin/src/main/kotlin/com/facebook/testing/screenshot/build/ScreenshotsPlugin.kt
+++ b/plugin/src/main/kotlin/com/facebook/testing/screenshot/build/ScreenshotsPlugin.kt
@@ -71,14 +71,11 @@ class ScreenshotsPlugin : Plugin<Project> {
   private fun generateTasksFor(project: Project, variant: TestVariant) {
     variant.outputs.all {
       if (it is ApkVariantOutput) {
-        val cleanScreenshots =createTask(
+        val cleanScreenshots = createTask(
             project,
             CleanScreenshotsTask.taskName(variant),
             variant,
             CleanScreenshotsTask::class.java)
-        project.tasks.getByName("clean")
-            .dependsOn(cleanScreenshots)
-
         createTask(
             project,
             PullScreenshotsTask.taskName(variant),
@@ -101,7 +98,7 @@ class ScreenshotsPlugin : Plugin<Project> {
             project,
             VerifyScreenshotTestTask.taskName(variant),
             variant,
-                VerifyScreenshotTestTask::class.java)
+            VerifyScreenshotTestTask::class.java)
 
       }
     }


### PR DESCRIPTION
Summary: I was working on an Android project and found myself opening
hundreds of reports on different browser tabs. For one thing that
takes up my /tmp space, for another that's just an inefficient
workflow.

I updated the plugin to generate the reports into a fixed directory
under ./build, so you can just keep the tab open and keep refreshing
it after every run.

Test plan: Ran ./gradlew :install, on my app used 0.8.0-SNAPSHOT and
specified mavenLocal() repositories. Then ran `./gradlew
:app:connectedAndroidTest :app:pullScreenshots` and saw the fixed link.

Also verified it was running the clean step, and that `./gradlew
:app:clean` ran the screenshot cleaning step too.

PS. While working on this, I noticed the "screenshotTests" task seems
to be have disappeared in 0.8.0-SNAPSHOT. Not sure if that's a
regression or intentional. Also "recordMode" and "verifyMode"
disappeared so I couldn't test those)