### PR TITLE
 Add setMaxPixels to RecordBuilder interface

### DIFF
--- a/core/src/main/java/com/facebook/testing/screenshot/RecordBuilder.java
+++ b/core/src/main/java/com/facebook/testing/screenshot/RecordBuilder.java
@@ -52,6 +52,14 @@ public interface RecordBuilder {
    */
   Bitmap getBitmap();
 
+  /**
+   * Set the maximum number of pixels this screenshot should produce. Producing any number higher
+   * will throw an exception.
+   *
+   * @param maxPixels Maximum number of pixels this screenshot should produce. <= 0 for no limit.
+   */
+  public RecordBuilder setMaxPixels(long maxPixels);
+
   /** Finish the recording. */
   void record();
 }

--- a/core/src/main/java/com/facebook/testing/screenshot/internal/RecordBuilderImpl.java
+++ b/core/src/main/java/com/facebook/testing/screenshot/internal/RecordBuilderImpl.java
@@ -115,12 +115,8 @@ public class RecordBuilderImpl implements RecordBuilder {
     return mScreenshotImpl.getBitmap(this);
   }
 
-  /**
-   * Set the maximum number of pixels this screenshot should produce. Producing any number higher
-   * will throw an exception.
-   *
-   * @param maxPixels Maximum number of pixels this screenshot should produce. <= 0 for no limit.
-   */
+  /** @inherit */
+  @Override
   public RecordBuilderImpl setMaxPixels(long maxPixels) {
     mMaxPixels = maxPixels;
     return this;


### PR DESCRIPTION
Right now, you have to cast the result of `Screenshot.snap()` to call this.  I assume that was not the intention.