### PR TITLE
Remove extraneous build tool versioning

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -21,7 +21,6 @@ group = 'com.facebook.testing.screenshot'
 
 android {
   compileSdkVersion versions.compileSdk
-  buildToolsVersion versions.buildTools
 
   packagingOptions {
     exclude 'LICENSE.txt'

--- a/layout-hierarchy-common/build.gradle
+++ b/layout-hierarchy-common/build.gradle
@@ -21,7 +21,6 @@ group = 'com.facebook.testing.screenshot'
 
 android {
   compileSdkVersion versions.compileSdk
-  buildToolsVersion versions.buildTools
 
   packagingOptions {
     exclude 'LICENSE.txt'

--- a/layout-hierarchy-litho/build.gradle
+++ b/layout-hierarchy-litho/build.gradle
@@ -21,7 +21,6 @@ group = 'com.facebook.testing.screenshot'
 
 android {
   compileSdkVersion versions.compileSdk
-  buildToolsVersion versions.buildTools
 
   packagingOptions {
     exclude 'LICENSE.txt'

--- a/plugin/src/test/groovy/com/facebook/testing/screenshot/build/ScreenshotsPluginTest.groovy
+++ b/plugin/src/test/groovy/com/facebook/testing/screenshot/build/ScreenshotsPluginTest.groovy
@@ -48,7 +48,6 @@ class ScreenshotsPluginTest {
 
     project.android {
       compileSdkVersion 22
-      buildToolsVersion "26.0.1"
 
       defaultConfig {
         applicationId appId

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -29,7 +29,6 @@ apply plugin: 'com.facebook.testing.screenshot'
 
 android {
   compileSdkVersion versions.compileSdk
-  buildToolsVersion versions.buildTools
   defaultConfig {
     applicationId "com.facebook.testing.screenshot.example"
     minSdkVersion 15

--- a/versions.gradle
+++ b/versions.gradle
@@ -9,7 +9,6 @@ ext {
       targetSdk : 26,
       compileSdk: 26,
       minSdk    : 9,
-      buildTools: '27.0.3',
   ]
 
   plugs = [


### PR DESCRIPTION
The Android Gradle Plugin now automatically downloads a pinned version of build tools.