### PR TITLE
Make tests pass

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -39,6 +39,9 @@ android {
 }
 
 dependencies {
+
+  compileOnly deps.jsr305
+
   androidTestImplementation deps.dexmaker
   androidTestImplementation deps.dexmakerDx
 

--- a/plugin/src/py/android_screenshot_tests/pull_screenshots.py
+++ b/plugin/src/py/android_screenshot_tests/pull_screenshots.py
@@ -113,8 +113,8 @@ def show_old_result(
 
 def generate_html(
     output_dir,
-    test_img_api,
-    old_imgs_data,
+    test_img_api=None,
+    old_imgs_data=None,
 ):
     # Take in:
     # output_dir a directory with imgs and data outputted by the just-run test,
@@ -181,7 +181,7 @@ def generate_html(
             else:
                 hierarchy = get_view_hierarchy(output_dir, screenshot)
                 html.write('<div class="flex-wrapper">')
-                comparing = test_img_api is not None
+                comparing = test_img_api is not None and old_imgs_data is not None
                 if comparing:
                     show_old_result(
                         canonical_name,

--- a/versions.gradle
+++ b/versions.gradle
@@ -33,6 +33,8 @@ ext {
       lithoAnnotations    : "com.facebook.litho:litho-annotations:$lithoVersion",
       lithoProcessor      : "com.facebook.litho:litho-processor:$lithoVersion",
 
+      jsr305              : "com.google.code.findbugs:jsr305:3.0.2",
+
       screenshotTestCommon: "com.facebook.testing.screenshot:layout-hierarchy-common:$screenshotTestVersion",
       screenshotTestLitho : "com.facebook.testing.screenshot:layout-hierarchy-litho:$screenshotTestVersion",
 

--- a/versions.gradle
+++ b/versions.gradle
@@ -2,14 +2,14 @@
 
 ext {
   final screenshotTestVersion = VERSION_NAME
-  final supportLibraryVersion = '28.0.0'
+  final supportLibraryVersion = '27.1.1'
   final dexmakerVersion = "1.4"
   final lithoVersion = "0.19.0"
 
   versions = [
       kotlin    : '1.2.71',
-      targetSdk : 28,
-      compileSdk: 28,
+      targetSdk : 27,
+      compileSdk: 27,
       minSdk    : 9,
   ]
 


### PR DESCRIPTION
Building the plug-in and running the tests by following the instructions in the README (`gradle :plugin:pyTests` and `gradle :core:connectedAndroidTest`) is currently not possible because of a broken test and a missing dependency. This pull request addresses both issues and builds at least on my machine (MacOS X 10.13). There isn't a publicly available CI server that I somehow didn't spot?