### PR TITLE
Make sample app compile again

### DIFF
--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -59,6 +59,7 @@ dependencies {
     exclude group: 'com.android.support', module: 'support-annotations'
     exclude group: 'com.google.code.findbugs', module: 'jsr305'
   }
+  androidTestImplementation deps.androidTestRules
 }
 
 screenshots {

--- a/versions.gradle
+++ b/versions.gradle
@@ -8,8 +8,8 @@ ext {
 
   versions = [
       kotlin    : '1.2.71',
-      targetSdk : 26,
-      compileSdk: 26,
+      targetSdk : 28,
+      compileSdk: 28,
       minSdk    : 9,
   ]
 
@@ -41,6 +41,7 @@ ext {
       "dexmakerMockito"   : "com.crittercism.dexmaker:dexmaker-mockito:$dexmakerVersion",
 
       "espresso"          : "com.android.support.test.espresso:espresso-core:3.0.2",
+      "androidTestRules"  : "com.android.support.test:rules:1.0.2",
       "junit"             : "junit:junit:4.12",
       "mockito"           : "org.mockito:mockito-core:1.10.19",
       "hamcrest"          : "org.hamcrest:hamcrest-core:1.3",


### PR DESCRIPTION
Due to missing dependencies and a mismatch between the compile SDK version and the support library's version, the sample app cannot be compiled without errors.