### PR TITLE
Handle absence of Play Services

### DIFF
--- a/plugin/src/py/android_screenshot_tests/device_name_calculator.py
+++ b/plugin/src/py/android_screenshot_tests/device_name_calculator.py
@@ -1,6 +1,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 
 import re
+import subprocess
 
 from .adb_executor import AdbExecutor
 
@@ -63,8 +64,11 @@ class DeviceNameCalculator:
             return density.group(0)
 
     def _has_play_services(self):
-        output = self.executor.execute(['shell', 'pm', 'path', 'com.google.android.gms'])
-        return True if output else False
+        try:
+            output = self.executor.execute(['shell', 'pm', 'path', 'com.google.android.gms'])
+            return True if output else False
+        except subprocess.CalledProcessError:
+            return False
 
     def _play_services_text(self):
         play_services = self._has_play_services()

--- a/plugin/src/py/android_screenshot_tests/test_device_name_calculator.py
+++ b/plugin/src/py/android_screenshot_tests/test_device_name_calculator.py
@@ -1,5 +1,5 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
-
+import subprocess
 import sys
 import unittest
 
@@ -167,3 +167,16 @@ class TestDeviceNameCalculator(unittest.TestCase):
         result = device_calculator._screen_density_text()
 
         assert result == "XXXHDPI"
+
+    def test_absent_gms_gracefully_handled(self):
+        adb_executor = MagicMock()
+        adb_executor.execute.side_effect = subprocess.CalledProcessError(
+            returncode=1,
+            cmd=["irrelevant"]
+        )
+
+        device_calculator = DeviceNameCalculator(adb_executor)
+
+        result = device_calculator._has_play_services()
+
+        assert not result


### PR DESCRIPTION
On a stock Android emulator, com.google.android.gms is not available and consequently the command execution fails with an exception. This change ensures that this situation is properly handled.