### PR TITLE
Loop over serials in ANDROID_SERIAL when pulling images (#140)

### DIFF
--- a/plugin/src/py/android_screenshot_tests/common.py
+++ b/plugin/src/py/android_screenshot_tests/common.py
@@ -14,8 +14,9 @@
 # limitations under the License.
 
 import os
-import sys
+import re
 import subprocess
+import sys
 
 def get_image_file_name(name, x, y):
     image_file = name
@@ -46,3 +47,11 @@ def assertRegex(testcase, regex, string):
         testcase.assertRegex(regex, string)
     else:
         testcase.assertRegexpMatches(regex, string)
+
+def get_connected_devices():
+    try:
+        output = check_output([get_adb(), "devices"]).splitlines()
+        target_pattern = re.compile(r"\b(device|emulator)\b")
+        return [line.split()[0] for line in output if target_pattern.search(line) and "offline" not in line]
+    except subprocess.CalledProcessError:
+        return None

--- a/plugin/src/py/android_screenshot_tests/pull_screenshots.py
+++ b/plugin/src/py/android_screenshot_tests/pull_screenshots.py
@@ -558,7 +558,7 @@ def main(argv):
     elif "ANDROID_SERIAL" in os.environ:
         passed_serials = os.environ.get('ANDROID_SERIAL').split(",")
     else:
-        passed_serials = None
+        passed_serials = common.get_connected_devices()
 
     if passed_serials:
         puller_args_list = [base_puller_args + ["-s", serial] for serial in passed_serials]

--- a/plugin/src/py/android_screenshot_tests/pull_screenshots.py
+++ b/plugin/src/py/android_screenshot_tests/pull_screenshots.py
@@ -543,28 +543,38 @@ def main(argv):
 
     should_perform_pull = ("--no-pull" not in opts)
 
-    puller_args = []
-    if "-e" in opts:
-        puller_args.append("-e")
-
-    if "-d" in opts:
-        puller_args.append("-d")
-
-    if "-s" in opts:
-        puller_args += ["-s", opts["-s"]]
-
     multiple_devices = opts.get('--multiple-devices')
     device_calculator = DeviceNameCalculator() if multiple_devices else NoOpDeviceNameCalculator()
 
-    return pull_screenshots(process,
-                            perform_pull=should_perform_pull,
-                            temp_dir=opts.get('--temp-dir'),
-                            filter_name_regex=opts.get('--filter-name-regex'),
-                            opt_generate_png=opts.get('--generate-png'),
-                            record=opts.get('--record'),
-                            verify=opts.get('--verify'),
-                            adb_puller=SimplePuller(puller_args),
-                            device_name_calculator=device_calculator)
+    base_puller_args = []
+    if "-e" in opts:
+        base_puller_args.append("-e")
+
+    if "-d" in opts:
+        base_puller_args.append("-d")
+
+    if "-s" in opts:
+        passed_serials = [opts['-s']]
+    elif "ANDROID_SERIAL" in os.environ:
+        passed_serials = os.environ.get('ANDROID_SERIAL').split(",")
+    else:
+        passed_serials = None
+
+    if passed_serials:
+        puller_args_list = [base_puller_args + ["-s", serial] for serial in passed_serials]
+    else:
+        puller_args_list = [base_puller_args]
+
+    for puller_args in puller_args_list:
+        pull_screenshots(process,
+                         perform_pull=should_perform_pull,
+                         temp_dir=opts.get('--temp-dir'),
+                         filter_name_regex=opts.get('--filter-name-regex'),
+                         opt_generate_png=opts.get('--generate-png'),
+                         record=opts.get('--record'),
+                         verify=opts.get('--verify'),
+                         adb_puller=SimplePuller(puller_args),
+                         device_name_calculator=device_calculator)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I didn't figure out how to properly test this, as `SimplePuller` isn't injected. I have verified manually that this works for all combinations (no variable set, variable set with 1 value, with multiple values).

I decided to use `ANDROID_SERIAL` instead of looping over all available devices since it's supposed to work with connected tests as well (https://issuetracker.google.com/issues/36990135#comment14).