### PR TITLE
Add failureDir

### DIFF
--- a/plugin/src/main/kotlin/com/facebook/testing/screenshot/build/PullScreenshotsTask.kt
+++ b/plugin/src/main/kotlin/com/facebook/testing/screenshot/build/PullScreenshotsTask.kt
@@ -80,6 +80,11 @@ open class PullScreenshotsTask : ScreenshotTask() {
           add(extension.recordDir)
         }
 
+        if (verify && extension.failureDir != null) {
+            add("--failure-dir")
+            add("${extension.failureDir}")
+        }
+
         if (extension.multipleDevices) {
           add("--multiple-devices")
           add("${extension.multipleDevices}")

--- a/plugin/src/main/kotlin/com/facebook/testing/screenshot/build/ScreenshotsPlugin.kt
+++ b/plugin/src/main/kotlin/com/facebook/testing/screenshot/build/ScreenshotsPlugin.kt
@@ -34,6 +34,8 @@ open class ScreenshotsPluginExtension {
   var pythonExecutable = "python"
   /** The directory to compare screenshots from in verify only mode */
   var referenceDir: String? = null
+  /** The directory to save failed screenshots */
+  var failureDir: String? = null
 }
 
 class ScreenshotsPlugin : Plugin<Project> {

--- a/plugin/src/py/android_screenshot_tests/pull_screenshots.py
+++ b/plugin/src/py/android_screenshot_tests/pull_screenshots.py
@@ -486,7 +486,8 @@ def pull_screenshots(process,
                      verify=None,
                      opt_generate_png=None,
                      test_img_api=None,
-                     old_imgs_data=None):
+                     old_imgs_data=None,
+                     failure_dir=None):
     if not perform_pull and temp_dir is None:
         raise RuntimeError("""You must supply a directory for temp_dir if --no-pull is present""")
 
@@ -508,10 +509,19 @@ def pull_screenshots(process,
     record_dir = join(record, device_name) if record and device_name else record
     verify_dir = join(verify, device_name) if verify and device_name else verify
 
+    if failure_dir:
+        failure_dir = join(failure_dir, device_name) if device_name else failure_dir
+        if not os.path.exists(failure_dir):
+            os.makedirs(failure_dir)
+
+    print('RecordDir: %s' % record_dir)
+    print('VerifyDir: %s' % verify_dir)
+    # print('FailureDir: %s' % failure_dir)
+    
     if record or verify:
         # don't import this early, since we need PIL to import this
         from .recorder import Recorder
-        recorder = Recorder(temp_dir, record_dir or verify_dir)
+        recorder = Recorder(temp_dir, record_dir or verify_dir, failure_dir)
         if verify:
             recorder.verify()
         else:
@@ -539,7 +549,7 @@ def main(argv):
         opt_list, rest_args = getopt.gnu_getopt(
             argv[1:],
             "eds:",
-            ["generate-png=", "filter-name-regex=", "apk", "record=", "verify=", "temp-dir=",
+            ["generate-png=", "filter-name-regex=", "apk", "record=", "verify=", "failure-dir=", "temp-dir=",
              "no-pull", "multiple-devices="])
     except getopt.GetoptError:
         usage()
@@ -590,7 +600,8 @@ def main(argv):
                          record=opts.get('--record'),
                          verify=opts.get('--verify'),
                          adb_puller=SimplePuller(puller_args),
-                         device_name_calculator=device_calculator)
+                         device_name_calculator=device_calculator,
+                         failure_dir=opts.get("--failure-dir"))
 
 
 if __name__ == '__main__':

--- a/plugin/src/py/android_screenshot_tests/pull_screenshots.py
+++ b/plugin/src/py/android_screenshot_tests/pull_screenshots.py
@@ -513,10 +513,6 @@ def pull_screenshots(process,
         failure_dir = join(failure_dir, device_name) if device_name else failure_dir
         if not os.path.exists(failure_dir):
             os.makedirs(failure_dir)
-
-    print('RecordDir: %s' % record_dir)
-    print('VerifyDir: %s' % verify_dir)
-    # print('FailureDir: %s' % failure_dir)
     
     if record or verify:
         # don't import this early, since we need PIL to import this

--- a/plugin/src/py/android_screenshot_tests/recorder.py
+++ b/plugin/src/py/android_screenshot_tests/recorder.py
@@ -88,7 +88,7 @@ class Recorder:
             shutil.rmtree(self._output)
         os.makedirs(self._output)
 
-    def _is_image_same(self, file1, file2, file3):
+    def _is_image_same(self, file1, file2, failure_file):
         with Image.open(file1) as im1, Image.open(file2) as im2:
             diff_image = ImageChops.difference(im1, im2)
             try:
@@ -96,11 +96,11 @@ class Recorder:
                 if diff is None:
                     return True
                 else:
-                    if file3:
+                    if failure_file:
                         diff_list = list(diff) if diff else []
                         draw = ImageDraw.Draw(im2)
                         draw.rectangle(diff_list, outline = (255,0,0))
-                        im2.save(file3)
+                        im2.save(failure_file)
                     return False
             finally:
                 diff_image.close()


### PR DESCRIPTION
Save screenshot diff, like iOS plugin.
Tests will not fail after the first failure, instead they will create files with all the failures and color up diff.
Output will be like:
```
<failure-dir>/<device>/foobar_actual.png //taked screenshot
<failure-dir>/<device>/foobar_expected.png //saved screenshot
<failure-dir>/<device>/foobar_diff.png //colored diff
```
build.gradle
```
  screenshots {
      failureDir = path/to/screenshots //"$projectDir/build/failure-screenshots"
  }
```
if u not specify dir plugin will work as before.