### PR TITLE
Replace use of deprecated Gradle API.

### DIFF
--- a/plugin/src/main/kotlin/com/facebook/testing/screenshot/build/RunScreenshotTestTask.kt
+++ b/plugin/src/main/kotlin/com/facebook/testing/screenshot/build/RunScreenshotTestTask.kt
@@ -34,7 +34,7 @@ open class RunScreenshotTestTask : PullScreenshotsTask() {
       return
     }
 
-    dependsOn(variant.connectedInstrumentTest)
-    mustRunAfter(variant.connectedInstrumentTest)
+    dependsOn(variant.connectedInstrumentTestProvider)
+    mustRunAfter(variant.connectedInstrumentTestProvider)
   }
 }


### PR DESCRIPTION
Both `dependsOn` and `mustRunAfter` [can accept a `Provider`](https://docs.gradle.org/current/javadoc/org/gradle/api/Task.html#dependencies) so this should be a straight API swap.

Fixes: #210 