### PR TITLE
Allow to record from multiple devices even if they connected at same time

### DIFF
--- a/plugin/src/py/android_screenshot_tests/device_name_calculator.py
+++ b/plugin/src/py/android_screenshot_tests/device_name_calculator.py
@@ -20,8 +20,9 @@ from .adb_executor import AdbExecutor
 
 class DeviceNameCalculator:
 
-    def __init__(self, executor=AdbExecutor()):
+    def __init__(self, executor=AdbExecutor(), args = []):
         self.executor = executor
+        self.args = args 
 
     def name(self):
         api_version_text = self._api_version_text()
@@ -64,20 +65,20 @@ class DeviceNameCalculator:
         return 'XXXHDPI'
 
     def _screen_density(self):
-        result = self.executor.execute(['shell', 'wm', 'density'])
+        result = self.executor.execute(self.args + ['shell', 'wm', 'density'])
         density = re.search('[0-9]+', result)
         if density:
             return density.group(0)
 
     def _screen_size_text(self):
-        result = self.executor.execute(['shell', 'wm', 'size'])
+        result = self.executor.execute(self.args + ['shell', 'wm', 'size'])
         density = re.search('[0-9]+x[0-9]+', result)
         if density:
             return density.group(0)
 
     def _has_play_services(self):
         try:
-            output = self.executor.execute(['shell', 'pm', 'path', 'com.google.android.gms'])
+            output = self.executor.execute(self.args + ['shell', 'pm', 'path', 'com.google.android.gms'])
             return True if output else False
         except subprocess.CalledProcessError:
             return False
@@ -87,16 +88,16 @@ class DeviceNameCalculator:
         return 'GP' if play_services else 'NO_GP'
 
     def _api_version(self):
-        return self.executor.execute(['shell', 'getprop', 'ro.build.version.sdk'])
+        return self.executor.execute(self.args + ['shell', 'getprop', 'ro.build.version.sdk'])
 
     def _api_version_text(self):
         return 'API_{0}'.format(int(self._api_version()))
 
     def _architecture_text(self):
-        architecture = self.executor.execute(['shell', 'getprop', 'ro.product.cpu.abi'])
+        architecture = self.executor.execute(self.args + ['shell', 'getprop', 'ro.product.cpu.abi'])
         return architecture.rstrip()
 
     def _locale(self):
-        persist_locale = self.executor.execute(['shell', 'getprop', 'persist.sys.locale'])
-        product_locale = self.executor.execute(['shell', 'getprop', 'ro.product.locale'])
+        persist_locale = self.executor.execute(self.args + ['shell', 'getprop', 'persist.sys.locale'])
+        product_locale = self.executor.execute(self.args + ['shell', 'getprop', 'ro.product.locale'])
         return persist_locale.rstrip() if persist_locale else product_locale.rstrip()

--- a/plugin/src/py/android_screenshot_tests/pull_screenshots.py
+++ b/plugin/src/py/android_screenshot_tests/pull_screenshots.py
@@ -506,6 +506,7 @@ def pull_screenshots(process,
 
     path_to_html = generate_html(temp_dir, test_img_api, old_imgs_data)
     device_name = device_name_calculator.name() if device_name_calculator else None
+
     record_dir = join(record, device_name) if record and device_name else record
     verify_dir = join(verify, device_name) if verify and device_name else verify
 
@@ -566,7 +567,6 @@ def main(argv):
     should_perform_pull = ("--no-pull" not in opts)
 
     multiple_devices = opts.get('--multiple-devices')
-    device_calculator = DeviceNameCalculator() if multiple_devices else NoOpDeviceNameCalculator()
 
     base_puller_args = []
     if "-e" in opts:
@@ -582,12 +582,16 @@ def main(argv):
     else:
         passed_serials = common.get_connected_devices()
 
-    if passed_serials:
-        puller_args_list = [base_puller_args + ["-s", serial] for serial in passed_serials]
-    else:
-        puller_args_list = [base_puller_args]
+    puller_args_list = []
+    device_calculator_list = []
+    for serial in (passed_serials or []):
+        puller_args_list.append(base_puller_args + ["-s", serial])
+        device_calculator_list.append(DeviceNameCalculator(args=["-s", serial]) if multiple_devices else NoOpDeviceNameCalculator())
+    if not len(puller_args_list):
+        puller_args_list.append(base_puller_args)
+        device_calculator_list.append(NoOpDeviceNameCalculator())
 
-    for puller_args in puller_args_list:
+    for index, puller_args in enumerate(puller_args_list):
         pull_screenshots(process,
                          perform_pull=should_perform_pull,
                          temp_dir=opts.get('--temp-dir'),
@@ -596,7 +600,7 @@ def main(argv):
                          record=opts.get('--record'),
                          verify=opts.get('--verify'),
                          adb_puller=SimplePuller(puller_args),
-                         device_name_calculator=device_calculator,
+                         device_name_calculator=device_calculator_list[index],
                          failure_dir=opts.get("--failure-dir"))
 
 


### PR DESCRIPTION
Hi. I have a hub of devices that permanently connected. In 0.11.0 it's not possible even to record screenshots in that case. Because DeviceNameCalulator fails to obtain name of device. This simple fix makes `record` comand work as expected. 

Btw, I don't like that `run` command overwrite generated html, if you run it on multiple devices. I don't fix this code because I think that it can be a breaking change for someone infrastracture, but I hope that in future run command will also support multiple devices. 