### PR TITLE
PythonExcutable was not use properly

### DIFF
--- a/plugin/src/main/kotlin/com/facebook/testing/screenshot/build/PullScreenshotsTask.kt
+++ b/plugin/src/main/kotlin/com/facebook/testing/screenshot/build/PullScreenshotsTask.kt
@@ -65,7 +65,7 @@ open class PullScreenshotsTask : ScreenshotTask() {
     assert(if (isVerifyOnly) outputDir.exists() else !outputDir.exists())
 
     project.exec {
-      it.executable = "python"
+      it.executable = extension.pythonExecutable
       it.environment("PYTHONPATH", jarFile)
 
       it.args = mutableListOf(


### PR DESCRIPTION
There is a nice field to setup the python executable but it was not use properly. This PR fix this so we can use it properly?