### PR TITLE
Add annotations for compatibility with Gradle 7.0

### DIFF
--- a/plugin/src/main/kotlin/com/facebook/testing/screenshot/build/PullScreenshotsTask.kt
+++ b/plugin/src/main/kotlin/com/facebook/testing/screenshot/build/PullScreenshotsTask.kt
@@ -20,6 +20,7 @@ import com.android.build.gradle.api.ApkVariantOutput
 import com.android.build.gradle.api.TestVariant
 import java.io.File
 import org.gradle.api.Project
+import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.TaskAction
 
 open class PullScreenshotsTask : ScreenshotTask() {
@@ -31,9 +32,14 @@ open class PullScreenshotsTask : ScreenshotTask() {
   }
 
   private lateinit var apkPath: File
+
+  @Input
   protected var verify = false
+
+  @Input
   protected var record = false
 
+  @Input
   protected lateinit var testRunId: String
 
   init {

--- a/plugin/src/main/kotlin/com/facebook/testing/screenshot/build/ScreenshotTask.kt
+++ b/plugin/src/main/kotlin/com/facebook/testing/screenshot/build/ScreenshotTask.kt
@@ -18,9 +18,13 @@ package com.facebook.testing.screenshot.build
 
 import com.android.build.gradle.api.TestVariant
 import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.Input
 
 open class ScreenshotTask : DefaultTask() {
+  @Input
   protected lateinit var extension: ScreenshotsPluginExtension
+
+  @Input
   protected lateinit var variant: TestVariant
 
   open fun init(variant: TestVariant, extension: ScreenshotsPluginExtension) {


### PR DESCRIPTION
(This PR won't compile until #282 or similar is merged)

Gradle 7.0 verifies that all the task properties are either inputs or outputs (https://docs.gradle.org/current/userguide/upgrading_version_6.html#task_validation_problems_are_now_errors). From looking at the plugin code I figured all the properties are inputs, although I'm not certain this is 100% correct. For example from what I see `variant: TestVariant` is actually both an input and output, depending on the task, but since the property is declared on the base class it's not a straightforward change to have this accurately annotated.

I decided to just add `@Input` annotations everywhere because this will at least make the plugin work again. However, it's only because no task declares outputs, and so up-to-date checks are off. This is desired behavior, because Android's connected check tasks are never up-to-date themselves, so screenshot tasks never being up-to-date makes sense too. But please note this would have to be explicitly declared (e.g. with `outputs.upToDateWhen { false }` or by linking the up-to-date check to connected test task) if any task has an `@Output` declared in the future.

I verified the fix with `./gradlew validatePlugins` task and by running `record` and `verify` tasks on my own project with a locally published snapshot (sample doesn't seem to work with Gradle 7 either).

Fixes #281 