### PR TITLE
Bump Gradle to 7.2 and Kotlin to 1.5.30

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/plugin/src/main/kotlin/com/facebook/testing/screenshot/build/CleanScreenshotsTask.kt
+++ b/plugin/src/main/kotlin/com/facebook/testing/screenshot/build/CleanScreenshotsTask.kt
@@ -21,7 +21,7 @@ import org.gradle.api.tasks.TaskAction
 
 open class CleanScreenshotsTask : ScreenshotTask() {
   companion object {
-    fun taskName(variant: TestVariant) = "clean${variant.name.capitalize()}Screenshots"
+    fun taskName(variant: TestVariant) = "clean${variant.name.replaceFirstChar { it.uppercase() }}Screenshots"
   }
 
   init {

--- a/plugin/src/main/kotlin/com/facebook/testing/screenshot/build/PullScreenshotsTask.kt
+++ b/plugin/src/main/kotlin/com/facebook/testing/screenshot/build/PullScreenshotsTask.kt
@@ -25,10 +25,10 @@ import org.gradle.api.tasks.TaskAction
 
 open class PullScreenshotsTask : ScreenshotTask() {
   companion object {
-    fun taskName(variant: TestVariant) = "pull${variant.name.capitalize()}Screenshots"
+    fun taskName(variant: TestVariant) = "pull${variant.name.replaceFirstChar { it.uppercase() }}Screenshots"
 
     fun getReportDir(project: Project, variant: TestVariant): File =
-        File(project.buildDir, "screenshots" + variant.name.capitalize())
+        File(project.buildDir, "screenshots" + variant.name.replaceFirstChar { it.uppercase() })
   }
 
   private lateinit var apkPath: File

--- a/plugin/src/main/kotlin/com/facebook/testing/screenshot/build/RecordScreenshotTestTask.kt
+++ b/plugin/src/main/kotlin/com/facebook/testing/screenshot/build/RecordScreenshotTestTask.kt
@@ -20,7 +20,7 @@ import com.android.build.gradle.api.TestVariant
 
 open class RecordScreenshotTestTask : RunScreenshotTestTask() {
   companion object {
-    fun taskName(variant: TestVariant) = "record${variant.name.capitalize()}ScreenshotTest"
+    fun taskName(variant: TestVariant) = "record${variant.name.replaceFirstChar { it.uppercase() }}ScreenshotTest"
   }
 
   init {

--- a/plugin/src/main/kotlin/com/facebook/testing/screenshot/build/RunScreenshotTestTask.kt
+++ b/plugin/src/main/kotlin/com/facebook/testing/screenshot/build/RunScreenshotTestTask.kt
@@ -20,7 +20,7 @@ import com.android.build.gradle.api.TestVariant
 
 open class RunScreenshotTestTask : PullScreenshotsTask() {
   companion object {
-    fun taskName(variant: TestVariant) = "run${variant.name.capitalize()}ScreenshotTest"
+    fun taskName(variant: TestVariant) = "run${variant.name.replaceFirstChar { it.uppercase() }}ScreenshotTest"
   }
 
   init {

--- a/plugin/src/main/kotlin/com/facebook/testing/screenshot/build/VerifyScreenshotTestTask.kt
+++ b/plugin/src/main/kotlin/com/facebook/testing/screenshot/build/VerifyScreenshotTestTask.kt
@@ -20,7 +20,7 @@ import com.android.build.gradle.api.TestVariant
 
 open class VerifyScreenshotTestTask : RunScreenshotTestTask() {
   companion object {
-    fun taskName(variant: TestVariant) = "verify${variant.name.capitalize()}ScreenshotTest"
+    fun taskName(variant: TestVariant) = "verify${variant.name.replaceFirstChar { it.uppercase() }}ScreenshotTest"
   }
 
   init {

--- a/versions.gradle
+++ b/versions.gradle
@@ -20,7 +20,7 @@ ext {
   final lithoVersion = "0.40.0"
 
   versions = [
-      kotlin    : '1.3.61',
+      kotlin    : '1.5.30',
       targetSdk : 28,
       compileSdk: 28,
       minSdk    : 14,


### PR DESCRIPTION
- Gradle and Kotlin need to be bumped together because Gradle Kotlin dependencies on reflect library
- Replaced deprecated capitalize() calls with replaceFirstChar