### PR TITLE
This image.close crashes 

### DIFF
--- a/plugin/src/py/android_screenshot_tests/recorder.py
+++ b/plugin/src/py/android_screenshot_tests/recorder.py
@@ -65,7 +65,6 @@ class Recorder:
                 input_file = common.get_image_file_name(name, i, j)
                 with Image.open(join(self._input, input_file)) as input_image:
                     im.paste(input_image, (i * tilewidth, j * tileheight))
-                    input_image.close()
 
         im.save(join(self._output, name + ".png"))
         im.close()


### PR DESCRIPTION
On my version of Python/PIL it crashes with:

```
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/home/arnold/.gradle/caches/jars-9/c0e3396506bdc4bbb1c7955ef2d0f623/plugin-0.15.0.jar/android_screenshot_tests/pull_screenshots.py", line 721, in <module>
  File "/home/arnold/.gradle/caches/jars-9/c0e3396506bdc4bbb1c7955ef2d0f623/plugin-0.15.0.jar/android_screenshot_tests/pull_screenshots.py", line 703, in main
  File "/home/arnold/.gradle/caches/jars-9/c0e3396506bdc4bbb1c7955ef2d0f623/plugin-0.15.0.jar/android_screenshot_tests/pull_screenshots.py", line 613, in pull_screenshots
  File "/home/arnold/.gradle/caches/jars-9/c0e3396506bdc4bbb1c7955ef2d0f623/plugin-0.15.0.jar/android_screenshot_tests/recorder.py", line 110, in record
  File "/home/arnold/.gradle/caches/jars-9/c0e3396506bdc4bbb1c7955ef2d0f623/plugin-0.15.0.jar/android_screenshot_tests/recorder.py", line 80, in _record
  File "/home/arnold/.gradle/caches/jars-9/c0e3396506bdc4bbb1c7955ef2d0f623/plugin-0.15.0.jar/android_screenshot_tests/recorder.py", line 66, in _copy
  File "/usr/lib/python3/dist-packages/PIL/Image.py", line 566, in __exit__
    self._fp.close()
    ^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/PIL/_util.py", line 19, in __getattr__
    raise self.ex
ValueError: Operation on closed image
```

The `with` block should handle the closing.

Test Plan: Before applying this change, did `./gradlew :*:publishToMavenLocal` and then ran `./gradlew :sample:recordDebugAndroidTestScreenshotTests`. Saw crash. Made changed. Re-ran publishToMavenLocal and the tests again, and it passes this time.