### PR TITLE
Migrate google java format from 1.7 -> 1.19.2

### DIFF
--- a/core/src/main/java/com/facebook/testing/screenshot/Screenshot.java
+++ b/core/src/main/java/com/facebook/testing/screenshot/Screenshot.java
@@ -49,7 +49,9 @@ public class Screenshot {
     return ScreenshotImpl.getInstance().snapActivity(activity);
   }
 
-  /** @return The largest amount of pixels we'll capture, otherwise an exception will be thrown. */
+  /**
+   * @return The largest amount of pixels we'll capture, otherwise an exception will be thrown.
+   */
   public static long getMaxPixels() {
     return ScreenshotImpl.getMaxPixels();
   }

--- a/core/src/main/java/com/facebook/testing/screenshot/internal/RecordBuilderImpl.java
+++ b/core/src/main/java/com/facebook/testing/screenshot/internal/RecordBuilderImpl.java
@@ -54,7 +54,9 @@ public class RecordBuilderImpl implements RecordBuilder {
     return mDescription;
   }
 
-  /** @inherit */
+  /**
+   * @inherit
+   */
   @Override
   public RecordBuilderImpl setDescription(String description) {
     mDescription = description;
@@ -68,7 +70,9 @@ public class RecordBuilderImpl implements RecordBuilder {
     return mName;
   }
 
-  /** @inherit */
+  /**
+   * @inherit
+   */
   @Override
   public RecordBuilderImpl setName(String name) {
     CharsetEncoder charsetEncoder = Charset.forName("latin-1").newEncoder();
@@ -112,20 +116,26 @@ public class RecordBuilderImpl implements RecordBuilder {
     return this;
   }
 
-  /** @inherit */
+  /**
+   * @inherit
+   */
   @Override
   public Bitmap getBitmap() {
     return mScreenshotImpl.getBitmap(this);
   }
 
-  /** @inherit */
+  /**
+   * @inherit
+   */
   @Override
   public RecordBuilderImpl setMaxPixels(long maxPixels) {
     mMaxPixels = maxPixels;
     return this;
   }
 
-  /** @return The maximum number of pixels that is expected to be produced by this screenshot */
+  /**
+   * @return The maximum number of pixels that is expected to be produced by this screenshot
+   */
   public long getMaxPixels() {
     return mMaxPixels;
   }
@@ -148,7 +158,9 @@ public class RecordBuilderImpl implements RecordBuilder {
     return this;
   }
 
-  /** @inherit */
+  /**
+   * @inherit
+   */
   @Override
   public void record() {
     mScreenshotImpl.record(this);
@@ -207,7 +219,9 @@ public class RecordBuilderImpl implements RecordBuilder {
     return this;
   }
 
-  /** @inherit */
+  /**
+   * @inherit
+   */
   @Override
   public RecordBuilderImpl setIncludeAccessibilityInfo(boolean includeAccessibilityInfo) {
     mIncludeAccessibilityInfo = includeAccessibilityInfo;

--- a/core/src/main/java/com/facebook/testing/screenshot/internal/ScreenshotDirectories.java
+++ b/core/src/main/java/com/facebook/testing/screenshot/internal/ScreenshotDirectories.java
@@ -135,6 +135,6 @@ class ScreenshotDirectories {
   private void setWorldWriteable(File dir) {
     // Context.MODE_WORLD_WRITEABLE has been deprecated, so let's
     // manually set this
-    dir.setWritable(/* writeable = */ true, /* ownerOnly = */ false);
+    dir.setWritable(/* writeable= */ true, /* ownerOnly= */ false);
   }
 }

--- a/core/src/main/java/com/facebook/testing/screenshot/internal/ScreenshotImpl.java
+++ b/core/src/main/java/com/facebook/testing/screenshot/internal/ScreenshotImpl.java
@@ -56,6 +56,7 @@ public class ScreenshotImpl {
   private static final int METADATA_VERSION = 1;
 
   private static ScreenshotImpl sInstance;
+
   /** The album of all the screenshots taken in this run. */
   private final Album mAlbum;
 
@@ -351,7 +352,9 @@ public class ScreenshotImpl {
     return ret[0];
   }
 
-  /** @return The largest amount of pixels we'll capture, otherwise an exception will be thrown. */
+  /**
+   * @return The largest amount of pixels we'll capture, otherwise an exception will be thrown.
+   */
   public static long getMaxPixels() {
     return RecordBuilderImpl.DEFAULT_MAX_PIXELS;
   }


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebook/SoLoader/pull/122

This diff migrates google java format form 1.7 to 1.19.2. This update will allow for new language features from java 17 and 21. This diff also formats all necessary files.

 Changelog:
    [Internal][Changed] - Updated format from google-java-format 1.7 -> 1.19.2

Reviewed By: IanChilds

Differential Revision: D52786052


